### PR TITLE
Update TriState and Analog descriptions

### DIFF
--- a/source/SpinalHDL/Libraries/IO/tristate.rst
+++ b/source/SpinalHDL/Libraries/IO/tristate.rst
@@ -1,3 +1,4 @@
+.. _section-tristate:
 
 TriState
 ========
@@ -5,14 +6,20 @@ TriState
 Introduction
 ------------
 
-SpinalHDL doesn't support natively tristates (inout) signals at the moment. The reason of that are :
-
+Tri-state signals are weird to handle in many cases:
 
 * They are not really kind of digital things
 * And except for IO, they aren't used for digital design
 * The tristate concept doesn't fit naturally in the SpinalHDL internal graph.
 
-Of course it's possible to add a native tristate support, but for the moment, the clean solution to manage them is to use an Tristate Bundle bus defined in the spinal.lib :
+SpinalHDL provides two different abstractions for tristate signals. The ``TriState`` bundle and :ref:`section-analog_and_inout` signals.
+Both serve different purposes:
+
+* TriState should be used for most purposes, especially within a design. The bundle contains an additional signal to carry the current direction.
+* ``Analog`` and ``inout`` should be used for drivers on the device boundary and in some other special cases. See the referenced documentation page for more details.
+
+As stated above, the recommended approach is to use ``TriState`` within a design. On the top-level the ``TriState`` bundle is then assigned to an analog inout to get the
+synthesis tools to infer the correct I/O driver. This can be done automatically done via the :ref:`InOutWrapper <section-analog_and_inout>` or manually if needed.
 
 TriState
 --------
@@ -31,9 +38,10 @@ The TriState bundle is defined as following :
      }
    }
 
-Then, as a master, you can use the ``read`` signal to read the outside value, you can use the ``writeEnable`` to enable your output, and finally use the ``write`` to set the value that you want to drive on the output.
+A master can use the ``read`` signal to read the outside value, the ``writeEnable`` to enable the output,
+and finally use ``write`` to set the value that is driven on the output.
 
-There is an example of usage :
+There is an example of usage:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Other language features/analog_inout.rst
+++ b/source/SpinalHDL/Other language features/analog_inout.rst
@@ -1,4 +1,6 @@
 
+.. _section-analog_and_inout:
+
 Analog and inout
 ================
 
@@ -7,12 +9,11 @@ Introduction
 
 You can define native tristate signals by using the Analog/inout features. These features were added for the following reasons:
 
+* Being able to add native tristate signals to the toplevel (it avoids having to manually wrap them with some hand-written VHDL/Verilog)
+* Allowing the definition of blackboxes which contain inout pins
+* Being able to connect a blackbox's inout pin through the hierarchy to a toplevel inout pin.
 
-* Being able to add native tristate signals to the toplevel (it avoid having to manualy wrap them with some hand written VHDL/Verilog)
-* Allowing the definition of blackbox which contains some inout pins
-* Being able to connect a blackbox inout through the hierarchy to a toplevel inout pin.
-
-As those feature were only added for convenance, do not do other fancy stuff with it and if you want to model a component like an memory mapped GPIO peripheral, please use the TriState/TriStateArray bundles from the spinal lib, which keep the true nature of the tristate driver.
+As those feature were only added for convenience, do not do other fancy stuff with it. If you want to model a component like an memory mapped GPIO peripheral, please use the :ref:`TriState/TriStateArray <section-tristate>` bundles from the spinal lib, which keep the true nature of the tristate driver.
 
 Analog
 ------
@@ -56,7 +57,7 @@ For instance:
 InOutWrapper
 ------------
 
-``InOutWrapper`` is a tool which allows you to tranform all master TriState/TriStateArray/ReadableOpenDrain bundles of a component into native inout(Analog(...)) signals. It allow you to keep all your hardware description without any Analog/inout things, and then transform the toplevel to make it synthesis ready.
+``InOutWrapper`` is a tool which allows you to tranform all master TriState/TriStateArray/ReadableOpenDrain bundles of a component into native inout(Analog(...)) signals. It allows you to keep all your hardware description without any Analog/inout things, and then transform the toplevel to make it synthesis ready.
 
 For instance:
 
@@ -113,3 +114,21 @@ Instead of:
        reset : in std_logic
      );
    end Apb3Gpio;
+
+Manually driving Analog bundles
+-------------------------------
+
+If an Analog bundle is not driven, it will default to being high-Z.
+Therefore to manually implement a tristate driver (in case the ``InOutWrapper`` can't be used for some reason) you have to
+conditionally drive the signal. To manually connect a ``TriState`` signal to an Analog bundle:
+
+.. code-block:: scala
+
+    case class Example extends Component {
+      val io = new Bundle {
+        val tri = slave(TriState(Bits(16 bit)))
+        val analog = inout Analog(Bits(16 bit))
+      }
+      tri.read := analog
+      when(tri.writeEnable) { analog := tri.write }
+    }


### PR DESCRIPTION
As discussed a few days ago on gitter, the TriState documentation is a bit out-of-date.
I therefore would propose to:
- Remove notes from TriState that state that Analog is not yet implemented
- Cross-reference TriState and Analog pages
- Add notes about how to drive Analog manually
- Fix minor typos