### PR TITLE
Fix grammar/formatting in About SpinalHDL section

### DIFF
--- a/source/SpinalHDL/About SpinalHDL/faq.rst
+++ b/source/SpinalHDL/About SpinalHDL/faq.rst
@@ -7,39 +7,40 @@ FAQ
 What is the overhead of SpinalHDL generated RTL compared to human written VHDL/Verilog?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The overhead is null, SpinalHDL is not an HLS approach. Its goal is not to translate any arbitrary code into RTL, but to provide a powerful language to describe RTL and rise the abstraction level.
+The overhead is null, SpinalHDL is not an HLS approach. Its goal is not to translate any arbitrary code into RTL, but to provide a powerful language to describe RTL and raise the abstraction level.
 
 What if SpinalHDL becomes unsupported in the future?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-| This question has two sides.
-| First: SpinalHDL generates VHDL/Verilog files, which means that SpinalHDL will be supported by all EDA tools for many decades.
-| Second: If there is a bug in SpinalHDL and there is no longer support to fix it, it's not a deadly situation, because the SpinalHDL compiler is fully open source. Maybe you will be able to fix the issue in few hours. Remember how much time it takes to EDA companies to fix issues or to add new features in their closed tools.
+This question has two sides:
+
+1. SpinalHDL generates VHDL/Verilog files, which means that SpinalHDL will be supported by all EDA tools for many decades.
+2. If there is a bug in SpinalHDL and there is no longer support to fix it, it's not a deadly situation, because the SpinalHDL compiler is fully open source. For simple issues, you may be able to fix the issue yourself in few hours. Remember how much time it takes to EDA companies to fix issues or to add new features in their closed tools.
 
 Does SpinalHDL keep comments in generated VHDL/verilog?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-No, it doesn't. Generated files should be considerate as a netlist. For example, when you compile C code, do you care about your comments in the generated assembly code?
+No, it doesn't. Generated files should be considered as a netlist. For example, when you compile C code, do you care about your comments in the generated assembly code?
 
 Could SpinalHDL scale up to big projects?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Yes, some experiments were done, and it appears that generating hundreds of 3KLUT CPUs with caches takes something like 12 seconds, which is a ridiculous time compared to the time required to simulate or synthesize this kind of design.
+Yes, some experiments were done, and it appears that generating hundreds of 3KLUT CPUs with caches takes around 12 seconds, which is a ridiculously short time compared to the time required to simulate or synthesize this kind of design.
 
 How SpinalHDL came to be
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Between December 2014 and April 2016, it was as a personal hobby project. But since April 2016 one person is working full time on it. Some people are also regularly contributing to the project.
 
-Why develop a new language when there is VHDL/Verilog/SystemVerilog
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why develop a new language when there is VHDL/Verilog/SystemVerilog?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :ref:`This page <regular_hdl>`\  is dedicated to this topic.
 
-How to use an unreleased version of SpinalHDL (but commited on git)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How to use an unreleased version of SpinalHDL (but committed on git)?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For instance, if you wanna try the ``dev`` branch, do the following in a dummy folder :
+For instance, if you want to try the ``dev`` branch, do the following in a dummy folder :
 
 .. code-block:: sh
 
@@ -48,6 +49,6 @@ For instance, if you wanna try the ``dev`` branch, do the following in a dummy f
    sbt clean publishLocal
 
 | Then in your project, don't forget to update the SpinalHDL version specified in the build.sbt file, see
-| `https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt#L10 <https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt#L10>`_.
+| `https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt#L10 <https://github.com/SpinalHDL/SpinalTemplateSbt/blob/master/build.sbt#L10>`_
 | To know which version you have to set, look in
 | `https://github.com/SpinalHDL/SpinalHDL/blob/dev/project/Version.scala#L7 <https://github.com/SpinalHDL/SpinalHDL/blob/dev/project/Version.scala#L7>`_

--- a/source/SpinalHDL/About SpinalHDL/support.rst
+++ b/source/SpinalHDL/About SpinalHDL/support.rst
@@ -7,20 +7,20 @@ Support
 Communication channels
 ----------------------
 
-| For bug reporting and feature requests, do not hesitate to emit github issues:
+| For bug reporting and feature requests, do not hesitate to create github issues:
 | `https://github.com/SpinalHDL/SpinalHDL/issues <https://github.com/SpinalHDL/SpinalHDL/issues>`_
 
-| For questions about the SpinalHDL syntax and live talks, a github channel is available:
+| For questions about SpinalHDL syntax and live talks, a Gitter channel is available:
 | `https://gitter.im/SpinalHDL/SpinalHDL <https://gitter.im/SpinalHDL/SpinalHDL>`_
 
-| For questions you can also use the forum StackOverflow with the tag SpinalHDL :
+| For questions, you can also use the forum StackOverflow with the tag SpinalHDL :
 | `https://stackoverflow.com/ <https://stackoverflow.com/>`_
 
-| A google group is also available. Feel free to post whatever subject you want related to SpinalHDL:
+| A Google group is also available. Feel free to post whatever subject you want related to SpinalHDL:
 | `https://groups.google.com/forum/#!forum/spinalhdl-hardware-description-language <https://groups.google.com/forum/#!forum/spinalhdl-hardware-description-language>`_
 
 Commercial support
 ------------------
 
-| If you are interested in a presentation, a workshop or consulting, do not hesitate to contact us by email:
+| If you are interested in a presentation, a workshop, or consulting, do not hesitate to contact us by email:
 | spinalhdl@gmail.com

--- a/source/SpinalHDL/About SpinalHDL/users.rst
+++ b/source/SpinalHDL/About SpinalHDL/users.rst
@@ -1,15 +1,15 @@
 Users
 =====
 
-Compagnies
-----------
+Companies
+---------
 
-QsPin, Belgium
+* QsPin, Belgium
 
 .. _users_repositories:
 
 Repositories
 ------------
 
-`J1Sc Stack CPU <https://github.com/SteffenReith/J1Sc>`_
-`VexRiscv CPU and SoC <https://github.com/SpinalHDL/VexRiscv>`_
+* `J1Sc Stack CPU <https://github.com/SteffenReith/J1Sc>`_
+* `VexRiscv CPU and SoC <https://github.com/SpinalHDL/VexRiscv>`_


### PR DESCRIPTION
This PR consists of small formatting, spelling, and grammatical fixes for the "About SpinalHDL" section of the docs.