### PR TITLE
Copyediting fixes for VHDL Help.

### DIFF
--- a/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_perspective.rst
+++ b/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_perspective.rst
@@ -9,14 +9,14 @@ Entity and architecture
 
 In SpinalHDL, a VHDL entity and architecture are both defined inside a ``Component``.
 
-Here is an example of a component which has 3 inputs (a,b,c) and an output (result). This component also has an ``offset`` construction parameter (like a VHDL generic)
+Here is an example of a component which has 3 inputs (``a``, ``b``, ``c``) and an output (``result``). This component also has an ``offset`` construction parameter (like a VHDL generic).
 
 .. code-block:: scala
 
    case class MyComponent(offset: Int) extends Component {
      val io = new Bundle{
-       val a,b,c  = in UInt(8 bits)
-       val result = out UInt(8 bits)
+       val a, b, c = in UInt(8 bits)
+       val result  = out UInt(8 bits)
      }
      io.result := a + b + c + offset
    }
@@ -25,7 +25,7 @@ Then to instantiate that component, you don't need to bind it:
 
 .. code-block:: scala
 
-   case class TopLevel extends Component{
+   case class TopLevel extends Component {
      ...
      val mySubComponent = MyComponent(offset = 5)
 
@@ -59,8 +59,8 @@ SpinalHDL data types are similar to the VHDL ones:
      - SInt
 
 
-| While for defining an 8 bit ``unsigned`` in VHDL you have to give the range of bits ``unsigned(7 downto 0)``, 
-| in SpinalHDL you simply supply the number of bits ``UInt(8 bits)``.
+| In VHDL, to define an 8 bit ``unsigned`` you have to give the range of bits ``unsigned(7 downto 0)``,
+| whereas in SpinalHDL you simply supply the number of bits ``UInt(8 bits)``.
 
 .. list-table::
    :header-rows: 1
@@ -74,16 +74,15 @@ SpinalHDL data types are similar to the VHDL ones:
    * - enum
      - SpinalEnum
 
-
-Here is an example of the SpinalHDL Bundle definition. ``channelWidth`` is a construction parameter, like VHDL generics, but for data structures:
+Here is an example of the SpinalHDL ``Bundle`` definition. ``channelWidth`` is a construction parameter, like VHDL generics, but for data structures:
 
 .. code-block:: scala
 
    case class RGB(channelWidth: Int) extends Bundle {
-     val r,g,b = UInt(channelWidth bits)
+     val r, g, b = UInt(channelWidth bits)
    }
 
-Then for example, to instantiate a Bundle, you need to write ``val myColor = RGB(channelWidth=8)``.
+Then for example, to instantiate a ``Bundle``, you need to write ``val myColor = RGB(channelWidth=8)``.
 
 Signal
 ------
@@ -93,47 +92,47 @@ Here is an example about signal instantiations:
 .. code-block:: scala
 
    case class MyComponent(offset: Int) extends Component {
-     val io = new Bundle{
-       val a,b,c  = UInt(8 bits)
-       val result = UInt(8 bits)
+     val io = new Bundle {
+       val a, b, c = UInt(8 bits)
+       val result  = UInt(8 bits)
      }
      val ab = UInt(8 bits)
      ab := a + b
 
-     val abc = ab + c            //You can define a signal directly with its value
+     val abc = ab + c            // You can define a signal directly with its value
      io.result := abc + offset
    }
 
-Assignements
-------------
+Assignments
+-----------
 
-In SpinalHDL, the ``:=`` assignment operator is equivalent to the VHDL signal assignment (<=):
+In SpinalHDL, the ``:=`` assignment operator is equivalent to the VHDL signal assignment (``<=``):
 
 .. code-block:: scala
 
    val myUInt = UInt(8 bits)
    myUInt := 6
 
-Conditional assignments are done like in VHDL by using ``if/case`` statements:
+Conditional assignments are done like in VHDL by using ``if``/``case`` statements:
 
 .. code-block:: scala
 
    val clear   = Bool
    val counter = Reg(UInt(8 bits))
 
-   when(clear){
+   when(clear) {
      counter := 0
-   }.elsewhen(counter === 76){
+   }.elsewhen(counter === 76) {
      counter := 79
-   }.otherwise{
+   }.otherwise {
      counter(7) := ! counter(7)
    }
 
-   switch(counter){
-     is(42){
+   switch(counter) {
+     is(42) {
        counter := 65
      }
-     default{
+     default {
        counter := counter + 1
      }
    }
@@ -155,27 +154,27 @@ Literals are a little bit different than in VHDL:
    myUInt := "xEE"
    myUInt := 42
    myUInt := U(54,8 bits)
-   myUInt := ((3 downto 0) -> myBool,default -> true)
-   when(myUInt === U(myUInt.range -> true)){
+   myUInt := ((3 downto 0) -> myBool, default -> true)
+   when(myUInt === U(myUInt.range -> true)) {
      myUInt(3) := False
    }
 
 Registers
 ---------
 
-In SpinalHDL, registers are explicitly specified while in VHDL it's inferred. Here is an example of SpinalHDL registers:
+In SpinalHDL, registers are explicitly specified while in VHDL registers are inferred. Here is an example of SpinalHDL registers:
 
 .. code-block:: scala
 
    val counter = Reg(UInt(8 bits))  init(0)  
-   counter := counter + 1   //Count up each cycle
+   counter := counter + 1   // Count up each cycle
 
-   //init(0) means that the register should be initialized to zero when a reset occurs
+   // init(0) means that the register should be initialized to zero when a reset occurs
 
 Process blocks
 --------------
 
-Process blocks are a simulation feature that is unnecessary to design RTL. It's why SpinalHDL doesn't contain any feature analog to process blocks, and you can assign what you want where you want.
+Process blocks are a simulation feature that is unnecessary to design RTL. It's why SpinalHDL doesn't contain any feature analogous to process blocks, and you can assign what you want, where you want.
 
 .. code-block:: scala
 
@@ -184,7 +183,7 @@ Process blocks are a simulation feature that is unnecessary to design RTL. It's 
    val myRegister = UInt(8 bits)
 
    myCombinatorial := False
-   when(cond)
+   when(cond) {
      myCombinatorial := True
      myRegister = myRegister + 1
    }


### PR DESCRIPTION
This PR includes the following changes:

 - Spelling and grammatical fixes
 - Formatting improvements (including more consistent formatting in code examples)