### PR TITLE
Copyediting fixes for Datatypes section.

### DIFF
--- a/source/SpinalHDL/Data types/Fix.rst
+++ b/source/SpinalHDL/Data types/Fix.rst
@@ -1,5 +1,5 @@
 .. warning::
-   The SpinalHDL fixed point support is only partially used/tested, if you find any bugs with it or you think that some functionality is missing, please create a github issue. Also, please do not use undocumented features in production code.
+   SpinalHDL fixed-point support is only partially used/tested, if you find any bugs with it, or you think that some functionality is missing, please create a `Github issue <https://github.com/SpinalHDL/SpinalHDL/issues>`_. Also, please do not use undocumented features in your code.
 
 .. _fixed:
 
@@ -9,14 +9,14 @@ UFix/SFix
 Description
 ^^^^^^^^^^^
 
-The ``UFix`` and ``SFix`` types correspond to a vector of bits that can be used for fixed point arithmetic.
+The ``UFix`` and ``SFix`` types correspond to a vector of bits that can be used for fixed-point arithmetic.
 
 Declaration
 ^^^^^^^^^^^
 
-The syntax to declare a fixed point number is as follows:
+The syntax to declare a fixed-point number is as follows:
 
-Unsigned Fixed Point
+Unsigned Fixed-Point
 ~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -39,8 +39,7 @@ Unsigned Fixed Point
      - 2^peak-2^(peak-width)
      - 0
 
-
-Signed Fixed Point
+Signed Fixed-Point
 ~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -63,14 +62,13 @@ Signed Fixed Point
      - 2^peak-2^(peak-width-1)
      - -(2^peak)
 
-
 Format
 ~~~~~~
 
-The chosen format follows the usual way of defining fixed point number format using Q notation. More information `there <https://en.wikipedia.org/wiki/Q_(number_format)>`_\ ).
+The chosen format follows the usual way of defining fixed-point number format using Q notation. More information can be found on the `Wikipedia page about the Q number format <https://en.wikipedia.org/wiki/Q_(number_format)>`_.
 
-For example Q8.2 will mean an fixed point of 8+2 bits, where 8 bit are used for the natural part and 2 bits for the fractional part.
-If the fixed point number is signed, one more bit is used for the sign.
+For example Q8.2 will mean a fixed-point number of 8+2 bits, where 8 bits are used for the natural part and 2 bits for the fractional part.
+If the fixed-point number is signed, one more bit is used for the sign.
 
 The resolution is defined as being the smallest power of two that can be represented in this number.
 
@@ -79,18 +77,18 @@ Examples
 
 .. code-block:: scala
 
-   // Unsigned Fixed Point
-   val UQ_8_2 = UFix(peak = 8 exp,resolution = -2 exp)
+   // Unsigned Fixed-Point
+   val UQ_8_2 = UFix(peak = 8 exp, resolution = -2 exp)
    val UQ_8_2 = UFix(8 exp, -2 exp)
 
-   val UQ_8_2 = UFix(peak = 8 exp,width = 10 bits)
+   val UQ_8_2 = UFix(peak = 8 exp, width = 10 bits)
    val UQ_8_2 = UFix(8 exp, 10 bits)
 
-   // Signed Fixed Point
-   val Q_8_2 = SFix(peak = 8 exp,resolution = -2 exp)
+   // Signed Fixed-Point
+   val Q_8_2 = SFix(peak = 8 exp, resolution = -2 exp)
    val Q_8_2 = SFix(8 exp, -2 exp)
 
-   val Q_8_2 = SFix(peak = 8 exp,width = 11 bits)
+   val Q_8_2 = SFix(peak = 8 exp, width = 11 bits)
    val Q_8_2 = SFix(8 exp, 11 bits)
 
 Assignments
@@ -99,22 +97,21 @@ Assignments
 Valid Assignments
 ~~~~~~~~~~~~~~~~~
 
-An assignment to a fixed point value is valid when there is no bit loss. Any bit loss will result in an error.
+An assignment to a fixed-point value is valid when there is no bit loss. Any bit loss will result in an error.
 
-If the source fixed point value is too big, the .truncated function will allow you to
-resize the source number to match the destination size.
+If the source fixed-point value is too big, the ``.truncated`` function will allow you to resize the source number to match the destination size.
 
 Example
 """""""
 
 .. code-block:: scala
 
-   val i16_m2 = SFix(16 exp,-2 exp)
-   val i16_0  = SFix(16 exp, 0 exp)
-   val i8_m2  = SFix( 8 exp,-2 exp)
-   val o16_m2 = SFix(16 exp,-2 exp)
-   val o16_m0 = SFix(16 exp, 0 exp)
-   val o14_m2 = SFix(14 exp,-2 exp)
+   val i16_m2 = SFix(16 exp, -2 exp)
+   val i16_0  = SFix(16 exp,  0 exp)
+   val i8_m2  = SFix( 8 exp, -2 exp)
+   val o16_m2 = SFix(16 exp, -2 exp)
+   val o16_m0 = SFix(16 exp,  0 exp)
+   val o14_m2 = SFix(14 exp, -2 exp)
 
    o16_m2 := i16_m2            // OK
    o16_m0 := i16_m2            // Not OK, Bit loss
@@ -125,22 +122,21 @@ Example
 From a Scala constant
 ~~~~~~~~~~~~~~~~~~~~~
 
-Scala BigInts or Doubles can be used as constants when assigning to UFix or SFix signals.
+Scala ``BigInt`` or ``Double`` types can be used as constants when assigning to ``UFix`` or ``SFix`` signals.
 
 Example
 """""""
 
 .. code-block:: scala
 
-   val i4_m2 = SFix(4 exp,-2 exp)
-   i4_m2 := 1.25    //Will load 5 in i4_m2.raw
-   i4_m2 := 4       //Will load 16 in i4_m2.raw
+   val i4_m2 = SFix(4 exp, -2 exp)
+   i4_m2 := 1.25    // Will load 5 in i4_m2.raw
+   i4_m2 := 4       // Will load 16 in i4_m2.raw
 
 Raw value
 ^^^^^^^^^
 
-The integer representation of the fixed point number can be read or written using the
-``raw`` property.
+The integer representation of the fixed-point number can be read or written by using the ``raw`` property.
 
 Example
 ~~~~~~~
@@ -148,13 +144,13 @@ Example
 .. code-block:: scala
 
    val UQ_8_2 = UFix(8 exp, 10 bits)
-   UQ_8_2.raw := 4        //Assign the value corresponding to 1.0
-   UQ_8_2.raw := U(17)    //Assign the value corresponding to 4.25
+   UQ_8_2.raw := 4        // Assign the value corresponding to 1.0
+   UQ_8_2.raw := U(17)    // Assign the value corresponding to 4.25
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``UFix`` type
+The following operators are available for the ``UFix`` type:
 
 Arithmetic
 ~~~~~~~~~~
@@ -196,7 +192,6 @@ Arithmetic
      - x.amplitude << y
      - x.resolution
 
-
 Comparison
 ~~~~~~~~~~
 
@@ -224,7 +219,6 @@ Comparison
    * - x >= y
      - Less than or equal
      - Bool
-
 
 Type cast
 ~~~~~~~~~
@@ -260,7 +254,6 @@ Type cast
    * - x.toSFix
      - Return the corresponding SFix
      - SFix
-
 
 Misc
 ~~~~

--- a/source/SpinalHDL/Data types/Floating.rst
+++ b/source/SpinalHDL/Data types/Floating.rst
@@ -1,5 +1,5 @@
 .. warning::
-   The SpinalHDL floating point support is under development and only partially used/tested, if you have any bug with it or you think that an functionality is missing, please create a github issue. Please, do not use undocumented features.
+   SpinalHDL floating-point support is under development and only partially used/tested, if you have any bugs with it, or you think that some functionality is missing, please create a `Github issue <https://github.com/SpinalHDL/SpinalHDL/issues>`_. Also, please do not use undocumented features in your code.
 
 .. _Floating:
 
@@ -9,12 +9,11 @@ Floating
 Description
 ^^^^^^^^^^^
 
-The ``Floating`` type corresponds to IEEE-754 encoded numbers. A second type called ``RecFloating`` helps in simplifying your design by recoding the floating point value simplify some edge cases in IEEE-754 floating point
+The ``Floating`` type corresponds to IEEE-754 encoded numbers. A second type called ``RecFloating`` helps in simplifying your design by recoding the floating-point value simplify some edge cases in IEEE-754 floating-point.
 
-It's composed of a sign bit, an exponent field and a mantissa field. The widths of the different fields are defined in the IEEE-754 or
-de-facto standards.
+It's composed of a sign bit, an exponent field and a mantissa field. The widths of the different fields are defined in the IEEE-754 or de-facto standards.
 
-This type can be used with the following import
+This type can be used with the following import:
 
 .. code-block:: scala
 
@@ -23,54 +22,51 @@ This type can be used with the following import
 IEEE-754 floating format
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-The numbers are encoded into IEEE-754 `floating point format <https://en.wikipedia.org/wiki/IEEE_floating_point>`_.
+The numbers are encoded into IEEE-754 `floating-point format <https://en.wikipedia.org/wiki/IEEE_floating_point>`_.
 
 Recoded floating format
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-Since IEEE-754 has some quirks about denormalized numbers and special values, Berkeley proposed another way of recoding floating
-point values.
+Since IEEE-754 has some quirks about denormalized numbers and special values, Berkeley proposed another way of recoding floating-point values.
 
 The mantissa is modified so that denormalized values can be treated the same as the normalized ones.
 
 The exponent field is one bit larger that one of the IEEE-754 number.
 
-The sign bit is kept unchanged between the two
-encodings.
+The sign bit is kept unchanged between the two encodings.
 
 Examples can be found `here <https://github.com/ucb-bar/berkeley-hardfloat/blob/master/README.md>`_
 
 Zero
 """"
 
-The zero is encoded with the three leading zeros of the exponent field being stuck to zero.
+The zero is encoded with the three leading zeros of the exponent field being set to zero.
 
 Denormalized values
 """""""""""""""""""
 
-Denormalized values are encoded in the same way as a normal floating point number. The mantissa is shifted so that the first one
-becomes implicit. The exponent is encoded as 107 (decimal) plus the index of the highest bit set to 1.
+Denormalized values are encoded in the same way as a normal floating-point number. The mantissa is shifted so that the first one becomes implicit.
+The exponent is encoded as 107 (decimal) plus the index of the highest bit set to 1.
 
 Normalized values
 """""""""""""""""
 
-The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent
-is encoded as 130 (decimal) plus the original exponent value.
+The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent is encoded as 130 (decimal) plus the original exponent value.
 
 Infinity
 """"""""
 
-The recoded mantissa value is treated as don't care. The recoded exponent three highest bits is 6 (decimal), the rest of the exponent can be treated as don't care.
+The recoded mantissa value is treated as don't care. The recoded exponent three highest bits is 6 (decimal), the rest of the exponent can be treated as don't cares.
 
 NaN
 """
 
-The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent three highest bits is 7 (decimal), the rest of the exponent can be treated as don't care.
+The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent three highest bits is 7 (decimal), the rest of the exponent can be treated as don't cares.
 
 Declaration
 ^^^^^^^^^^^
 
-The syntax to declare a floating point number is as follows:
+The syntax to declare a floating-point number is as follows:
 
 IEEE-754 Number
 ~~~~~~~~~~~~~~~
@@ -81,18 +77,17 @@ IEEE-754 Number
    * - Syntax
      - Description
    * - Floating(exponentSize: Int, mantissaSize: Int)
-     - IEEE-754 Floating point value with a custom exponent and mantissa size
+     - IEEE-754 Floating-point value with a custom exponent and mantissa size
    * - Floating16()
-     - IEEE-754 Half precision floating point number
+     - IEEE-754 Half precision floating-point number
    * - Floating32()
-     - IEEE-754 Single precision floating point number
+     - IEEE-754 Single precision floating-point number
    * - Floating64()
-     - IEEE-754 Double precision floating point number
+     - IEEE-754 Double precision floating-point number
    * - Floating128()
-     - IEEE-754 Quad precision floating point number
+     - IEEE-754 Quad precision floating-point number
 
-
-Recoded floating point number
+Recoded floating-point number
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. list-table::
@@ -101,21 +96,20 @@ Recoded floating point number
    * - Syntax
      - Description
    * - RecFloating(exponentSize: Int, mantissaSize: Int)
-     - Recoded Floating point value with a custom exponent and mantissa size
+     - Recoded Floating-point value with a custom exponent and mantissa size
    * - RecFloating16()
-     - Recoded Half precision floating point number
+     - Recoded Half precision floating-point number
    * - RecFloating32()
-     - Recoded Single precision floating point number
+     - Recoded Single precision floating-point number
    * - RecFloating64()
-     - Recoded Double precision floating point number
+     - Recoded Double precision floating-point number
    * - RecFloating128()
-     - Recoded Quad precision floating point number
-
+     - Recoded Quad precision floating-point number
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``Floating`` and ``RecFloating`` types
+The following operators are available for the ``Floating`` and ``RecFloating`` types:
 
 Type cast
 ~~~~~~~~~

--- a/source/SpinalHDL/Data types/Floating.rst
+++ b/source/SpinalHDL/Data types/Floating.rst
@@ -56,12 +56,12 @@ The recoded mantissa for normalized values is exactly the same as the original I
 Infinity
 """"""""
 
-The recoded mantissa value is treated as don't care. The recoded exponent three highest bits is 6 (decimal), the rest of the exponent can be treated as don't cares.
+The recoded mantissa value is treated as don't care. The recoded exponent three highest bits is 6 (decimal), the rest of the exponent can be treated as don't care.
 
 NaN
 """
 
-The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent three highest bits is 7 (decimal), the rest of the exponent can be treated as don't cares.
+The recoded mantissa for normalized values is exactly the same as the original IEEE-754 mantissa. The recoded exponent three highest bits is 7 (decimal), the rest of the exponent can be treated as don't care.
 
 Declaration
 ^^^^^^^^^^^

--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -51,7 +51,6 @@ The syntax to declare an integer is as follows:  (everything between [] is optio
      - | UInt
        | SInt
 
-
 .. code-block:: scala
 
    val myUInt = UInt(8 bits)
@@ -64,21 +63,21 @@ The syntax to declare an integer is as follows:  (everything between [] is optio
                            //               o (base 8)
                            //               b (base 2)                       
    myUInt := U"8'h1A"       
-   myUInt := 2             // You can use scala Int as literal value
+   myUInt := 2             // You can use a Scala Int as a literal value
 
    val myBool := myUInt === U(7 -> true,(6 downto 0) -> false)
    val myBool := myUInt === U(myUInt.range -> true)
 
-   // For assignement purposes, you can omit the U/S, which also alow the use of the [default -> ???] feature
-   myUInt := (default -> true)                        //Assign myUInt with "11111111"
-   myUInt := (myUInt.range -> true)                   //Assign myUInt with "11111111"
-   myUInt := (7 -> true, default -> false)            //Assign myUInt with "10000000"
-   myUInt := ((4 downto 1) -> true, default -> false) //Assign myUInt with "00011110"
+   // For assignment purposes, you can omit the U/S, which also allows the use of the [default -> ???] feature
+   myUInt := (default -> true)                        // Assign myUInt with "11111111"
+   myUInt := (myUInt.range -> true)                   // Assign myUInt with "11111111"
+   myUInt := (7 -> true, default -> false)            // Assign myUInt with "10000000"
+   myUInt := ((4 downto 1) -> true, default -> false) // Assign myUInt with "00011110"
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``UInt`` and ``SInt`` type
+The following operators are available for the ``UInt`` and ``SInt`` types:
 
 Logic
 ~~~~~
@@ -151,12 +150,11 @@ Logic
      - Set all bits to the given Bool value
      - 
 
-
 .. code-block:: scala
 
    // Bitwise operator
    val a, b, c = SInt(32 bits)
-   c := ~(a & b) //  Inverse(a AND b)
+   c := ~(a & b) // Inverse(a AND b)
 
    val all_1 = a.andR // Check that all bits are equal to 1
 
@@ -169,7 +167,7 @@ Logic
 
    // Set/clear
    val a = B"8'x42"
-   when(cond){
+   when(cond) {
      a.setAll() // set all bits to True when cond is True
    }
 
@@ -184,32 +182,31 @@ Arithmetic
      - Return
    * - x + y
      - Addition
-     - T(max(w(x), w(y)),bits)
+     - T(max(w(x), w(y)), bits)
    * - x +^ y
      - Addition with carray
-     - T(max(w(x), w(y) + 1),bits)
+     - T(max(w(x), w(y) + 1), bits)
    * - x +| y
-     - addition by sat carray bit
-     - T(max(w(x), w(y)),bits)
+     - Addition by sat carray bit
+     - T(max(w(x), w(y)), bits)
    * - x - y
      - Subtraction
-     - T(max(w(x), w(y)),bits)
+     - T(max(w(x), w(y)), bits)
    * - x - y
      - Subtraction with carray
      - T(max(w(x), w(y) + 1), bits)
    * - x -| y
      - Subtraction by sat carray bit
-     - T(max(w(x), w(y)),bits)
+     - T(max(w(x), w(y)), bits)
    * - x * y
      - Multiplication
      - T(w(x) + w(y)), bits)
    * - x / y
      - Division
-     - T(w(x),bits)
+     - T(w(x), bits)
    * - x % y
      - Modulo
-     - T(w(x),bits)
-
+     - T(w(x), bits)
 
 .. code-block:: scala
 
@@ -244,17 +241,16 @@ Comparison
      - Less than or equal
      - Bool
 
-
 .. code-block:: scala
 
-   // Comparaison between two SInt
+   // Comparison between two SInts
    myBool := mySInt_1 > mySInt_2
 
-   // Comparaison between a UInt and a literal
+   // Comparison between a UInt and a literal
    myBool := myUInt_8bits >= U(3, 8 bits)
 
-   when(myUInt_8bits === 3){
-
+   when(myUInt_8bits === 3) {
+     ..
    }
 
 Type cast
@@ -268,35 +264,34 @@ Type cast
      - Return
    * - x.asBits
      - Binary cast to Bits
-     - Bits(w(x),bits)
+     - Bits(w(x), bits)
    * - x.asUInt
      - Binary cast to UInt
-     - UInt(w(x),bits)
+     - UInt(w(x), bits)
    * - x.asSInt
      - Binary cast to SInt
-     - SInt(w(x),bits)
+     - SInt(w(x), bits)
    * - x.asBools
      - Cast into a array of Bool
      - Vec(Bool, w(x))
    * - S(x: T)
      - Cast a Data into a SInt
-     - SInt(w(x),bits)
+     - SInt(w(x), bits)
    * - U(x: T)
      - Cast a Data into an UInt
-     - UInt(w(x),bits)
+     - UInt(w(x), bits)
    * - x.intoSInt
      - convert to SInt expand signbit
      - SInt(w(x) + 1, bits)
 
-
-To cast a Bool, a Bits or a SInt into a UInt, you can use ``U(something)``. To cast things into a SInt, you can use ``S(something)``
+To cast a ``Bool``, a ``Bits``, or an ``SInt`` into a ``UInt``, you can use ``U(something)``. To cast things into an ``SInt``, you can use ``S(something)``.
 
 .. code-block:: scala
 
-   // cast a SInt to Bits
+   // Cast an SInt to Bits
    val myBits = mySInt.asBits
 
-   // create a Vector of bool
+   // Create a Vector of Bool
    val myVec = myUInt.asBools
 
    // Cast a Bits to SInt
@@ -330,7 +325,6 @@ Bit extraction
    * - x(\ :ref:`range <range>`\ ) := z
      - Assign a range of bit. Ex : myBits(4 downto 2) := U"010"
      - T(range bits)
-
 
 .. code-block:: scala
 
@@ -428,7 +422,7 @@ Misc
        // sel = 2 => mySIntWord = mySInt_128bits( 63 downto 32)
        // sel = 3 => mySIntWord = mySInt_128bits( 31 downto  0)
 
-    // if you want to access in a reverse order you can do
+    // If you want to access in reverse order you can do:
     val myVector   = mySInt_128bits.subdivideIn(32 bits).reverse
     val mySIntWord = myVector(sel)
 
@@ -444,22 +438,23 @@ Misc
    mySInt_abs := mySInt.abs
 
 
-fixPoint operation
-^^^^^^^^^^^^^^^^^^
+FixPoint operations
+^^^^^^^^^^^^^^^^^^^
 
-For fixed-point, we can divide it into two parts.
- - LowerBit Operation(round methods)
- - HighBit Operation(saturation operations)
+For fixpoint, we can divide it into two parts:
 
-Lower Bit operation
-~~~~~~~~~~~~~~~~~~~
+ - Lower bit operations (rounding methods)
+ - High bit operations (saturation operations)
+
+Lower bit operations
+~~~~~~~~~~~~~~~~~~~~
 
 .. image:: /asset/image/fixpoint/lowerBitOperation.png
 
 About Rounding: https://en.wikipedia.org/wiki/Rounding
 
 ================ ================= ============= ======================== ====================== ===========
- SpinalHDL-Name   Wikipedia-Name    API           Matmatic-Alogrithm        return(align=false)   Supported
+ SpinalHDL-Name   Wikipedia-Name    API           Mathematic Alogrithm     return(align=false)    Supported
 ================ ================= ============= ======================== ====================== ===========
  FLOOR            RoundDown         floor         floor(x)                  w(x)-n   bits         Yes
  FLOORTOZERO      RoundToZero       floorToZero   sign*floor(abs(x))        w(x)-n   bits         Yes
@@ -474,46 +469,45 @@ About Rounding: https://en.wikipedia.org/wiki/Rounding
 ================ ================= ============= ======================== ====================== ===========
 
 .. note::
-   the **RoundToEven RoundToOdd** are very special ,Used in some big data statistical fields with high accuracy concern, SpinalHDL don't support them yet.
+   The **RoundToEven** and **RoundToOdd** modes are very special, and are used in some big data statistical fields with high accuracy concerns, SpinalHDL doesn't support them yet.
 
-You can find **ROUNDUP, ROUNDDOWN, ROUNDTOZERO, ROUNDTOINF, ROUNDTOEVEN, ROUNTOODD** are very close,
-`ROUNDTOINF` is most common. the api of round in different Programing-language may different.
+You will find `ROUNDUP`, `ROUNDDOWN`, `ROUNDTOZERO`, `ROUNDTOINF`, `ROUNDTOEVEN`, `ROUNTOODD` are very close in behavior, `ROUNDTOINF` is the most common. The behavior of rounding in different programming languages may be different.
 
-===================== =================== ========================================================= ====================
- Programing-language   default-RoundType   Example                                                   comments
-===================== =================== ========================================================= ====================
- Matlab                ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
- python2               ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
- python3               ROUNDTOEVEN         round(1.5)=round(2.5)=2;  round(-1.5)=round(-2.5)=-2      close to Even
- Scala.math            ROUNDTOUP           round(1.5)=2,round(2.5)=3;round(-1.5)=-1,round(-2.5)=-2   always to +Infinity
- SpinalHDL             ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
-===================== =================== ========================================================= ====================
+====================== =================== ========================================================= ====================
+ Programming language  default-RoundType   Example                                                   comments
+====================== =================== ========================================================= ====================
+ Matlab                 ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
+ python2                ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
+ python3                ROUNDTOEVEN         round(1.5)=round(2.5)=2;  round(-1.5)=round(-2.5)=-2      close to Even
+ Scala.math             ROUNDTOUP           round(1.5)=2,round(2.5)=3;round(-1.5)=-1,round(-2.5)=-2   always to +Infinity
+ SpinalHDL              ROUNDTOINF          round(1.5)=2,round(2.5)=3;round(-1.5)=-2,round(-2.5)=-3   round to ±Infinity
+====================== =================== ========================================================= ====================
 
 .. note::
-   In SpinalHDL `ROUNDTOINF` is the default RoundType (`round = roundToInf`)
+   In SpinalHDL `ROUNDTOINF` is the default RoundType (``round = roundToInf``)
 
 .. code-block:: scala
 
    val A  = SInt(16 bit)
-   val B  = A.roundToInf(6 bits) //default 'align = false' with carry, got 11 bit
+   val B  = A.roundToInf(6 bits) // default 'align = false' with carry, got 11 bit
    val B  = A.roundToInf(6 bits, align = true) // sat 1 carry bit, got 10 bit
-   val B  = A.floor(6 bits)             //return 10 bit
-   val B  = A.floorToZero(6 bits)       //return 10 bit
-   val B  = A.ceil(6 bits)              //ceil with carry so return 11 bit
-   val B  = A.ceil(6 bits, align =true) //ceil with carry then sat 1 bit return 10 bit
+   val B  = A.floor(6 bits)             // return 10 bit
+   val B  = A.floorToZero(6 bits)       // return 10 bit
+   val B  = A.ceil(6 bits)              // ceil with carry so return 11 bit
+   val B  = A.ceil(6 bits, align = true) // ceil with carry then sat 1 bit return 10 bit
    val B  = A.ceilToInf(6 bits)
    val B  = A.roundUp(6 bits)
    val B  = A.roundDown(6 bits)
    val B  = A.roundToInf(6 bits)
    val B  = A.roundToZero(6 bits)
-   val B  = A.round(6 bits)             //spinalHDL use roundToInf as default round
+   val B  = A.round(6 bits)             // SpinalHDL uses roundToInf as the default rounding mode
 
-   val B0 = A.roundToInf(6 bits, align=true)          ---+
-                                                         |--> equal
-   val B1 = A.roundToInf(6 bits, align=false).sat(1)  ---+
+   val B0 = A.roundToInf(6 bits, align = true)         //  ---+
+                                                     //     |--> equal
+   val B1 = A.roundToInf(6 bits, align = false).sat(1) //  ---+
 
 .. note::
-   only `floor` and `floorToZero` without align option, they do not need carry bit. other round operation default with carry bit.
+   Only ``floor`` and ``floorToZero`` work without the ``align`` option; they do not need a carry bit. Other rounding operations default to using a carry bit.
 
 **round Api**
 
@@ -532,59 +526,58 @@ You can find **ROUNDUP, ROUNDDOWN, ROUNDTOZERO, ROUNDTOINF, ROUNDTOEVEN, ROUNTOO
 ============= =========== ============================ ===================== ====================
 
 .. note::
-   | although `roundToInf` is very common.
-   | but `roundUp` with lowerest cost and good timing, almost no performance lost.
-   | so `roundUp` is very recommended in your work.
+   Although ``roundToInf`` is very common, ``roundUp`` has the least cost and good timing, with almost no performance loss.
+   As a result, ``roundUp`` is strongly recommended for production use.
 
-High Bit operation
-~~~~~~~~~~~~~~~~~~
+High bit operations
+~~~~~~~~~~~~~~~~~~~
 
 .. image:: /asset/image/fixpoint/highBitOperation.png
 
-========== ============ ===================================== ======================================
+========== ============ ====================================== =======================================
  function   Operation    Postive-Op                            Negtive-Op                           
-========== ============ ===================================== ======================================
- sat        Saturation   when(Top[w-1,w-n].orR) set maxValue   When(Top[w-1,w-n].andR) set minValue 
- trim       Discard      N/A                                   N/A                                  
- symmetry   Symmetric    N/A                                   minValue = -maxValue                 
-========== ============ ===================================== ======================================
+========== ============ ====================================== =======================================
+ sat        Saturation   when(Top[w-1, w-n].orR) set maxValue   When(Top[w-1, w-n].andR) set minValue 
+ trim       Discard      N/A                                    N/A                                  
+ symmetry   Symmetric    N/A                                    minValue = -maxValue                 
+========== ============ ====================================== =======================================
 
-Symmetric is only valid for SInt.
+Symmetric is only valid for ``SInt``.
 
 .. code-block:: scala
 
    val A  = SInt(8 bit)
-   val B  = A.sat(3 bits)      //return 5 bits with saturated highest 3 bits
-   val B  = A.sat(3)           //equal to sat(3 bits)
-   val B  = A.trim(3 bits)     //return 5 bits with discard hightest 3 bits
-   val B  = A.trim(3 bits)     //return 5 bits with discard hightest 3 bits
-   val C  = A.symmetry         //return 8 bits and symmetry as (-128~127 to -127~127)
-   val C  = A.sat(3).symmetry  //return 5 bits and symmetry as (-16~15 to -15~15)
+   val B  = A.sat(3 bits)      // return 5 bits with saturated highest 3 bits
+   val B  = A.sat(3)           // equal to sat(3 bits)
+   val B  = A.trim(3 bits)     // return 5 bits with the highest 3 bits discarded
+   val B  = A.trim(3 bits)     // return 5 bits with the highest 3 bits discarded
+   val C  = A.symmetry         // return 8 bits and symmetry as (-128~127 to -127~127)
+   val C  = A.sat(3).symmetry  // return 5 bits and symmetry as (-16~15 to -15~15)
 
 fixTo function
 ~~~~~~~~~~~~~~
 
-two way are provided in UInt/SInt do fixpoint:
+Two ways are provided in ``UInt``/``SInt`` to do fixpoint:
 
 .. image:: /asset/image/fixpoint/fixPoint.png
 
-fixTo is strongly recommended in your RTL work, you don't need handle carry bit align and bit width calculate manually like Way1.
+``fixTo`` is strongly recommended in your RTL work, you don't need to handle carry bit alignment and bit width calculations manually like **Way1** in the above diagram.
 
-Factory Fix function with Auto Saturation
+Factory Fix function with Auto Saturation:
 
-=================================== ===================== ===================
- fuction                             description           Return
-=================================== ===================== ===================
- fixTo(section,roundType,symmetric)   Factory FixFunction   section.size bits
-=================================== ===================== ===================
+===================================== ===================== ===================
+ Function                              Description           Return
+===================================== ===================== ===================
+ fixTo(section, roundType, symmetric)  Factory FixFunction   section.size bits
+===================================== ===================== ===================
 
 .. code-block:: scala
 
    val A  = SInt(16 bit)
-   val B  = A.fixTo(10 downto 3) //default RoundType.ROUNDTOINF, sym = false
+   val B  = A.fixTo(10 downto 3) // default RoundType.ROUNDTOINF, sym = false
    val B  = A.fixTo( 8 downto 0, RoundType.ROUNDUP)
    val B  = A.fixTo( 9 downto 3, RoundType.CEIL,       sym = false)
    val B  = A.fixTo(16 downto 1, RoundType.ROUNDTOINF, sym = true )
-   val B  = A.fixTo(10 downto 3, RoundType.FLOOR) //floor 3 bit, sat 5 bit @ highest
-   val B  = A.fixTo(20 downto 3, RoundType.FLOOR) //floor 3 bit, expand 2 bit @ highest
+   val B  = A.fixTo(10 downto 3, RoundType.FLOOR) // floor 3 bit, sat 5 bit @ highest
+   val B  = A.fixTo(20 downto 3, RoundType.FLOOR) // floor 3 bit, expand 2 bit @ highest
 

--- a/source/SpinalHDL/Data types/Vec.rst
+++ b/source/SpinalHDL/Data types/Vec.rst
@@ -24,9 +24,9 @@ The syntax to declare a vector is as follows:
      - Description
    * - Vec(type: Data, size: Int)
      - Create a vector capable of holding ``size`` elements of type ``Data``
-   * - Vec(x,y,..)
-     - | Create a vector where indexes point to given elements. 
-       | this constructor supports mixed element width
+   * - Vec(x, y, ...)
+     - | Create a vector where indexes point to the provided elements.
+       | This constructor supports mixed element width.
 
 
 Examples
@@ -35,23 +35,23 @@ Examples
 .. code-block:: scala
 
    // Create a vector of 2 signed integers
-   val myVecOfSInt = Vec(SInt(8 bits),2)
+   val myVecOfSInt = Vec(SInt(8 bits), 2)
    myVecOfSInt(0) := 2
    myVecOfSInt(1) := myVecOfSInt(0) + 3
 
    // Create a vector of 3 different type elements
    val myVecOfMixedUInt = Vec(UInt(3 bits), UInt(5 bits), UInt(8 bits))
 
-   val x,y,z = UInt(8 bits)
-   val myVecOf_xyz_ref = Vec(x,y,z)
+   val x, y, z = UInt(8 bits)
+   val myVecOf_xyz_ref = Vec(x, y, z)
 
    // Iterate on a vector
-   for(element <- myVecOf_xyz_ref){
-     element := 0   //Assign x,y,z with the value 0
+   for(element <- myVecOf_xyz_ref) {
+     element := 0   // Assign x, y, z with the value 0
    }
 
    // Map on vector
-   myVecOfMixedUInt.map(_ := 0) // assign all element with value 0 
+   myVecOfMixedUInt.map(_ := 0) // Assign all elements with value 0
 
    // Assign 3 to the first element of the vector
    myVecOf_xyz_ref(1) := 3
@@ -59,7 +59,7 @@ Examples
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``Bundle`` type
+The following operators are available for the ``Vec`` type:
 
 Comparison
 ~~~~~~~~~~
@@ -84,7 +84,7 @@ Comparison
    val vec2 = Vec(SInt(8 bits), 2)
    val vec1 = Vec(SInt(8 bits), 2)
 
-   myBool := vec2 === vec1 // compare all elemenets
+   myBool := vec2 === vec1  // Compare all elemenets
 
 Type cast
 ~~~~~~~~~

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -201,7 +201,7 @@ Type cast
      -  Bits(w(x) bits)
 
 
-To cast a ``Bool``, ``UInt`` or an ``SInt`` into a ``Bits``, you can use ``B(something)`` as in the example below:
+To cast a ``Bool``, ``UInt`` or an ``SInt`` into a ``Bits``, you can use ``B(something)``:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -52,14 +52,14 @@ The syntax to declare a bit vector is as follows: (everything between [] is opti
 
    // Element
    val myBits5 = B(8 bits, default -> True) // "11111111"
-   val myBits6 = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false ) // "10111000"
+   val myBits6 = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false) // "10111000"
    val myBits7 = Bits(8 bits)
-   myBits7 := (7 -> true, default -> false) // "10000000" (For assignement purposes, you can omit the B)
+   myBits7 := (7 -> true, default -> false) // "10000000" (For assignment purposes, you can omit the B)
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``Bits`` type
+The following operators are available for the ``Bits`` type:
 
 Logic
 ~~~~~
@@ -129,12 +129,11 @@ Logic
      - Set all bits to the given Bool value
      - 
 
-
 .. code-block:: scala
 
    // Bitwise operator
    val a, b, c = Bits(32 bits)
-   c := ~(a & b) //  Inverse(a AND b)
+   c := ~(a & b) // Inverse(a AND b)
 
    val all_1 = a.andR // Check that all bits are equal to 1
 
@@ -147,7 +146,7 @@ Logic
 
    // Set/clear
    val a = B"8'x42"
-   when(cond){
+   when(cond) {
      a.setAll() // set all bits to True when cond is True
    }
 
@@ -170,10 +169,10 @@ Comparison
 
 .. code-block:: scala
 
-   when(myBits === 3){
+   when(myBits === 3) {
    }
 
-   when(myBits_32 =/= B"32'x44332211"){
+   when(myBits_32 =/= B"32'x44332211") {
    }
 
 Type cast
@@ -202,7 +201,7 @@ Type cast
      -  Bits(w(x) bits)
 
 
-To cast a Bool, UInt or a SInt into a Bits, you can use ``B(something)``
+To cast a ``Bool``, ``UInt`` or an ``SInt`` into a ``Bits``, you can use ``B(something)`` as in the example below:
 
 .. code-block:: scala
 
@@ -312,9 +311,9 @@ Misc
 
    println(myBits_32bits.getWidth) // 32
 
-   myBool := myBits.lsb  // equivalent to myBits(0)
+   myBool := myBits.lsb  // Equivalent to myBits(0)
 
-   // concatenation
+   // Concatenation
    myBits_24bits := bits_8bits_1 ## bits_8bits_2 ## bits_8bits_3
 
    // Subdivide
@@ -325,7 +324,7 @@ Misc
        // sel = 2 => myBitsWord = myBits_128bits( 63 downto 32)
        // sel = 3 => myBitsWord = myBits_128bits( 31 downto  0)
 
-    // if you want to access in a reverse order you can do
+    // If you want to access in reverse order you can do:
     val myVector   = myBits_128bits.subdivideIn(32 bits).reverse
     val myBitsWord = myVector(sel)
 

--- a/source/SpinalHDL/Data types/bool.rst
+++ b/source/SpinalHDL/Data types/bool.rst
@@ -94,12 +94,12 @@ Logic
    val res = (!a & b) ^ c   // ((NOT a) AND b) XOR c
 
    val d = False
-   when(cond){
+   when(cond) {
      d.set()    // equivalent to d := True
    }
 
    val e = False
-   e.setWhen(cond) // equivalent to when(cond){ d := True }
+   e.setWhen(cond) // equivalent to when(cond) { d := True }
 
 Edge detection
 ~~~~~~~~~~~~~~
@@ -139,19 +139,19 @@ Edge detection
 
 .. code-block:: scala
 
-   when(myBool_1.rise(False)){
+   when(myBool_1.rise(False)) {
        // do something when a rising edge is detected 
    } 
 
 
    val edgeBundle = myBool_2.edges(False)
-   when(edgeBundle.rise){
+   when(edgeBundle.rise) {
        // do something when a rising edge is detected
    }
-   when(edgeBundle.fall){
+   when(edgeBundle.fall) {
        // do something when a falling edge is detected
    }
-   when(edgeBundle.toggle){
+   when(edgeBundle.toggle) {
        // do something at each edge
    }
 
@@ -174,11 +174,11 @@ Comparison
 
 .. code-block:: scala
 
-   when(myBool){ // Equivalent to when(myBool === True)
+   when(myBool) { // Equivalent to when(myBool === True)
        // do something when myBool is True
    }
 
-   when(!myBool){ // Equivalent to when(myBool === False)
+   when(!myBool) { // Equivalent to when(myBool === False)
        // do something when myBool is False
    }
 

--- a/source/SpinalHDL/Data types/bundle.rst
+++ b/source/SpinalHDL/Data types/bundle.rst
@@ -7,10 +7,9 @@ Bundle
 Description
 ^^^^^^^^^^^
 
-The ``Bundle`` is a composite type that defines a group of named signals (of any SpinalHDL basic type)
-under a single name.
+The ``Bundle`` is a composite type that defines a group of named signals (of any SpinalHDL basic type) under a single name.
 
-A Bundle can be used to model data structures, buses and interfaces.
+A ``Bundle`` can be used to model data structures, buses, and interfaces.
 
 Declaration
 ^^^^^^^^^^^
@@ -30,15 +29,15 @@ For example, a bundle holding a color could be defined as:
 .. code-block:: scala
 
    case class Color(channelWidth: Int) extends Bundle {
-     val r,g,b = UInt(channelWidth bits)
+     val r, g, b = UInt(channelWidth bits)
    }
 
-You can find an APB3 definition example :ref:`there <example_apb3>`
+You can find an :ref:`APB3 definition <example_apb3>` among the :ref:`Spinal HDL examples <example_list>`.
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``Bundle`` type
+The following operators are available for the ``Bundle`` type:
 
 Comparison
 ~~~~~~~~~~
@@ -69,7 +68,6 @@ Comparison
    color2.g := 0 
    color2.b := 0
 
-
    myBool := color1 === color2
 
 Type cast
@@ -85,7 +83,6 @@ Type cast
      - Binary cast to Bits
      - Bits(w(x) bits)
 
-
 .. code-block:: scala
 
    val color1 = Color(8)
@@ -94,18 +91,18 @@ Type cast
 IO Element direction
 ^^^^^^^^^^^^^^^^^^^^
 
-When you define an Bundle inside the IO definition of your component, you need to specify its direction.
+When you define a ``Bundle`` inside the IO definition of your component, you need to specify its direction.
 
 in/out
 ~~~~~~
 
 If all elements of your bundle go in the same direction you can use ``in(MyBundle())`` or ``out(MyBundle())``.
 
-For example :
+For example:
 
 .. code-block:: scala
 
-   val io = new Bundle{
+   val io = new Bundle {
      val input  = in (Color(8))
      val output = out(Color(8))
    }
@@ -113,9 +110,9 @@ For example :
 master/slave
 ~~~~~~~~~~~~
 
-If your interface obeys to a master/slave topology, you can use the ``IMasterSlave`` trait. Then you have to implement the function ``def asMaster(): Unit`` to set the direction of each elements from an master perspective. Then you can use the ``master(MyBundle())`` and ``slave(MyBundle())`` syntax in the IO defintion.
+If your interface obeys to a master/slave topology, you can use the ``IMasterSlave`` trait. Then you have to implement the function ``def asMaster(): Unit`` to set the direction of each element from the master's perspective. Then you can use the ``master(MyBundle())`` and ``slave(MyBundle())`` syntax in the IO defintion.
 
-For example :
+For example:
 
 .. code-block:: scala
 
@@ -124,15 +121,15 @@ For example :
      val ready   = Bool
      val payload = Bits(payloadWidth bits)
 
-     //You have to implement this asMaster function.
-     //This function should set the direction of each signals from an master point of view
+     // You have to implement this asMaster function.
+     // This function should set the direction of each signals from an master point of view
      override def asMaster(): Unit = {
-       out(valid,payload)
+       out(valid, payload)
        in(ready)
      }
    }
 
-   val io = new Bundle{
+   val io = new Bundle {
      val input  = slave(HandShake(8))
      val output = master(HandShake(8))
    }

--- a/source/SpinalHDL/Data types/enum.rst
+++ b/source/SpinalHDL/Data types/enum.rst
@@ -21,23 +21,23 @@ The declaration of an enumerated data type is as follows:
    }
 
 For the example above, the default encoding is used.
-Native enumeration type is used for VHDL and a binary encoding is used for Verilog.
+The native enumeration type is used for VHDL and a binary encoding is used for Verilog.
 
 The enumeration encoding can be forced by defining the enumeration as follows:
 
 .. code-block:: scala
 
-   object Enumeration extends SpinalEnum(defaultEncoding=encodingOfYouChoice) {
+   object Enumeration extends SpinalEnum(defaultEncoding=encodingOfYourChoice) {
      val element0, element1, ..., elementN = newElement()
    }
    
 .. note::
-   If you want to define a enumeration as in/out of a given component, you have to do as following : in(MyEnum())  out(MyEnum())
+   If you want to define an enumeration as in/out for a given component, you have to do as following: ``in(MyEnum())`` or ``out(MyEnum())``
 
 Encoding
 ~~~~~~~~
 
-The following enumeration encodings are supported :
+The following enumeration encodings are supported:
 
 .. list-table::
    :header-rows: 1
@@ -49,47 +49,46 @@ The following enumeration encodings are supported :
    * - native
      - 
      - Use the VHDL enumeration system, this is the default encoding
-   * - binarySequancial
+   * - binarySequential
      - log2Up(stateCount)
      - Use Bits to store states in declaration order (value from 0 to n-1)
    * - binaryOneHot
      - stateCount
      - Use Bits to store state. Each bit corresponds to one state
 
-
-Custom encoding can be performed in two different ways: static or dynamic. 
+Custom encodings can be performed in two different ways: static or dynamic.
 
 .. code-block:: scala
 
    /* 
     * Static encoding 
     */
-   object MyEnumStatic extends SpinalEnum{
+   object MyEnumStatic extends SpinalEnum {
      val e0, e1, e2, e3 = newElement()
      defaultEncoding = SpinalEnumEncoding("staticEncoding")(
        e0 -> 0,
-       e1 -> 2, 
+       e1 -> 2,
        e2 -> 3,
        e3 -> 7)
    }
 
    /*
-    * Dynamic encoding with the function :  _ * 2 + 1 
-    *    e.g : e0 => 0 * 2 + 1 = 1 
+    * Dynamic encoding with the function :  _ * 2 + 1
+    *   e.g. : e0 => 0 * 2 + 1 = 1
     *          e1 => 1 * 2 + 1 = 3
-    *          e2 => 2 * 2 + 1 = 5 
-    *          e3 => 3 * 2 + 1 = 7 
+    *          e2 => 2 * 2 + 1 = 5
+    *          e3 => 3 * 2 + 1 = 7
     */
    val encoding = SpinalEnumEncoding("dynamicEncoding", _ * 2 + 1)
 
-   object MyEnumDynamic extends SpinalEnum(encoding){
+   object MyEnumDynamic extends SpinalEnum(encoding) {
      val e0, e1, e2, e3 = newElement()
    }
 
 Example
 ~~~~~~~
 
-Instantiate a enumerated signal and assign a value to it :
+Instantiate an enumerated signal and assign a value to it:
 
 .. code-block:: scala
 
@@ -100,14 +99,14 @@ Instantiate a enumerated signal and assign a value to it :
    val stateNext = UartCtrlTxState()
    stateNext := UartCtrlTxState.sIdle
 
-   //You can also import the enumeration to have the visibility on its elements
+   // You can also import the enumeration to have visibility of its elements
    import UartCtrlTxState._
    stateNext := sIdle
 
 Operators
 ^^^^^^^^^
 
-The following operators are available for the ``Enumeration`` type
+The following operators are available for the ``Enumeration`` type:
 
 Comparison
 ~~~~~~~~~~
@@ -133,16 +132,16 @@ Comparison
    val stateNext = UartCtrlTxState()
    stateNext := sIdle
 
-   when(stateNext === sStart){
-
+   when(stateNext === sStart) {
+     ...
    }
 
-   switch(stateNext){
-     is(sIdle){
-
+   switch(stateNext) {
+     is(sIdle) {
+       ...
      }
-     is(sStart){
-
+     is(sStart) {
+       ...
      }
      ...
    }
@@ -165,7 +164,6 @@ Type cast
    * - x.asSInt
      - Binary cast to SInt
      - SInt(w(x) bits)
-
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Data types/index.rst
+++ b/source/SpinalHDL/Data types/index.rst
@@ -19,7 +19,7 @@ Data types
 Introduction
 ============
 
-The language provides 5 base types and 2 composite types that can be used.
+The language provides 5 base types, and 2 composite types that can be used.
 
 
 * Base types: :ref:`Bool <Bool>` , :ref:`Bits <Bits>` , :ref:`UInt <Int>` for unsigned integers, :ref:`SInt <Int>` for signed integers and :ref:`Enum <Enum>`.
@@ -29,7 +29,10 @@ The language provides 5 base types and 2 composite types that can be used.
    :width: 400px
 
 
-In addition to the base types, Spinal supports Fixed point that is documented :ref:`here <fixed>` and floating point that is actually under development :ref:`here <Floating>`.
+In addition to the base types, Spinal has support under development for:
+
+* :ref:`Fixed-point <fixed>` numbers (partial support)
+* :ref:`Floating-point <Floating>` numbers (experimental support)
 
 Finally, a special type is available for checking equality between a BitVector and a bits constant that contains holes (don't care values). An example is shown below:
 

--- a/source/SpinalHDL/Examples/index.rst
+++ b/source/SpinalHDL/Examples/index.rst
@@ -2,6 +2,8 @@
 Examples
 ========
 
+.. _example_list:
+
 .. toctree::
    :glob:
 
@@ -15,11 +17,11 @@ Examples
 Introduction
 ============
 
-Examples are split in tree kinds:
+Examples are split into three kinds:
 
-* Simple ones that could be used to get used to the basics of SpinalHDL.
-* Intermediates ones which implement components by using a traditional approach.
-* Advanced ones which go further than traditional HDL by using object oriented programming, functional programming, and meta-hardware description.
+* Simple examples that could be used to get used to the basics of SpinalHDL.
+* Intermediate examples which implement components by using a traditional approach.
+* Advanced examples which go further than traditional HDL by using object-oriented programming, functional programming, and meta-hardware description.
 
 They are all accessible in the sidebar under the corresponding sections.
 
@@ -27,4 +29,4 @@ They are all accessible in the sidebar under the corresponding sections.
    The SpinalHDL workshop contains many labs with their solutions. See `here <https://github.com/SpinalHDL/SpinalWorkshop>`_.
 
 .. note::
-   You can also find a list of repostitories using SpinalHDL :ref:`there <users_repositories>`
+   You can also find a list of repostitories using SpinalHDL :ref:`here <users_repositories>`


### PR DESCRIPTION
This PR includes:

 - Basic spelling/grammatical/formatting fixes and improvements.
 - More descriptive hyperlink text where possible. ("here" -> "article
   on <topic>")
 - New link target to the Examples page, to make cross-linking easier.
 - Code examples are formatted more consistently now.
 - More code-style wrappers to highlight SpinalHDL types in the text.