### PR TITLE
Copyediting fixes for Structuring section.

### DIFF
--- a/source/SpinalHDL/Structuring/area.rst
+++ b/source/SpinalHDL/Structuring/area.rst
@@ -4,8 +4,8 @@
 Area
 ====
 
-Area
-----
+Introduction
+------------
 
 Sometimes, creating a ``Component`` to define some logic is overkill because you:
 
@@ -13,7 +13,7 @@ Sometimes, creating a ``Component`` to define some logic is overkill because you
 * Need to define all construction parameters and IO (verbosity, duplication)
 * Split your code (more than needed)
 
-For this kind of case you can use an ``Area`` to define a group of signals/logic.
+For this kind of case you can use an ``Area`` to define a group of signals/logic:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Structuring/blackbox.rst
+++ b/source/SpinalHDL/Structuring/blackbox.rst
@@ -7,13 +7,13 @@ Instantiate VHDL and Verilog IP
 Description
 -----------
 
-A blackbox allows the user to integrate an existing VHDL/Verilog component into the design by just specifying the
+A blackbox allows the user to integrate an existing VHDL/Verilog component into the design by just specifying its
 interfaces. It's up to the simulator or synthesizer to do the elaboration correctly.
 
 Defining an blackbox
 --------------------
 
- An example of how to define a blackbox is shown below:
+An example of how to define a blackbox is shown below:
 
 .. code-block:: scala
 
@@ -21,15 +21,15 @@ Defining an blackbox
    class Ram_1w_1r(wordWidth: Int, wordCount: Int) extends BlackBox {
 
      // SpinalHDL will look at Generic classes to get attributes which
-     // should be used ad VHDL gererics / Verilog parameter
-     // You can use String Int Double Boolean and all SpinalHDL base types
-     // as generic value
+     // should be used as VHDL generics / Verilog parameters
+     // You can use String, Int, Double, Boolean, and all SpinalHDL base
+     // types as generic values
      val generic = new Generic {
        val wordCount = Ram_1w_1r.this.wordCount
        val wordWidth = Ram_1w_1r.this.wordWidth
      }
 
-     // Define io of the VHDL entiry / Verilog module
+     // Define IO of the VHDL entity / Verilog module
      val io = new Bundle {
        val clk = in Bool
        val wr = new Bundle {
@@ -44,12 +44,12 @@ Defining an blackbox
        }
      }
 
-     //Map the current clock domain to the io.clk pin
+     // Map the current clock domain to the io.clk pin
      mapClockDomain(clock=io.clk)
    }
 
-| In VHDL, signals of type ``Bool`` will be translated into std_logic and ``Bits`` into std_logic_vector. If you want to get std_ulogic, you have to use a BlackBoxULogic instead of BlackBox.
-| In Verilog, BlackBoxUlogic has no effect. 
+| In VHDL, signals of type ``Bool`` will be translated into ``std_logic`` and ``Bits`` into ``std_logic_vector``. If you want to get ``std_ulogic``, you have to use a ``BlackBoxULogic`` instead of ``BlackBox``.
+| In Verilog, ``BlackBoxUlogic`` has no effect.
 
 .. code-block:: scala
 
@@ -80,7 +80,7 @@ There are two different ways to declare generics:
 Instantiating a blackbox
 ------------------------
 
-Instantiating a blackbox is just like instantiating a Component:
+Instantiating a ``BlackBox`` is just like instantiating a ``Component``:
 
 .. code-block:: scala
 
@@ -99,10 +99,10 @@ Instantiating a blackbox is just like instantiating a Component:
        }
      }
 
-     //Instantiate the blackbox
+     // Instantiate the blackbox
      val ram = new Ram_1w_1r(8,16)
 
-     //Connect all the signals
+     // Connect all the signals
      io.wr.en   <> ram.io.wr.en
      io.wr.addr <> ram.io.wr.addr
      io.wr.data <> ram.io.wr.data
@@ -120,7 +120,7 @@ Instantiating a blackbox is just like instantiating a Component:
 Clock and reset mapping
 -----------------------
 
-In your blackbox definition you have to explicitly define clock and reset wires. To map signals of a ClockDomain to corresponding inputs of the blackbox you can use the ``mapClockDomain`` or ``mapCurrentClockDomain`` function. ``mapClockDomain`` has the following parameters:
+In your blackbox definition you have to explicitly define clock and reset wires. To map signals of a ``ClockDomain`` to corresponding inputs of the blackbox you can use the ``mapClockDomain`` or ``mapCurrentClockDomain`` function. ``mapClockDomain`` has the following parameters:
 
 .. list-table::
    :header-rows: 1
@@ -207,6 +207,9 @@ In order to avoid the prefix "io\_" on each of the IOs of the blackbox, you can 
 Rename all io of a blackbox
 ---------------------------
 
+IOs of a ``BlackBox`` or ``Component`` can be renamed at compile-time using the ``addPrePopTask`` function.
+This function takes a no-argument function to be applied during compilation, and is useful for adding renaming passes, as shown in the following example:
+
 .. code-block:: scala
 
    class MyRam() extends Blackbox {
@@ -242,10 +245,10 @@ Rename all io of a blackbox
      }
 
      // Execute the function renameIO after the creation of the component 
-     addPrePostTask(() => renameIO())
+     addPrePopTask(() => renameIO())
    }
 
-   // This code generate those names :
+   // This code generate these names:
    //    clk 
    //    cs_A, rwn_A, dIn_A, dOut_A
    //    cs_B, rwn_B, dIn_B, dOut_B
@@ -253,7 +256,7 @@ Rename all io of a blackbox
 Add RTL source
 --------------
 
-With the function ``addRTLPath()`` you can associate your RTL sources with the blackbox. After the generation of your Spinal code you can call the fonction ``mergeRTLSource`` to merge all sources together. 
+With the function ``addRTLPath()`` you can associate your RTL sources with the blackbox. After the generation of your SpinalHDL code you can call the function ``mergeRTLSource`` to merge all of the sources together.
 
 .. code-block:: scala
 
@@ -277,23 +280,22 @@ With the function ``addRTLPath()`` you can associate your RTL sources with the 
      addRTLPath("./rtl/RegisterBank.v")                         // Add a verilog file 
      addRTLPath(s"./rtl/myDesign.vhd")                          // Add a vhdl file 
      addRTLPath(s"${sys.env("MY_PROJECT")}/myTopLevel.vhd")     // Use an environement variable MY_PROJECT (System.getenv("MY_PROJECT"))
-
    }
 
    ...
 
    val report = SpinalVhdl(new MyBlackBox)
-   report.mergeRTLSource("mergeRTL") // merge all rtl sources into mergeRTL.vhd and mergeRTL.v file
+   report.mergeRTLSource("mergeRTL") // Merge all rtl sources into mergeRTL.vhd and mergeRTL.v files
 
 VHDL - No numeric type
 ----------------------
 
-If you want to use only ``std_logic_vector`` on your blackbox component, you can add the tag ``noNumericType`` to the blackbox. 
+If you want to use only ``std_logic_vector`` in your blackbox component, you can add the tag ``noNumericType`` to the blackbox.
 
 .. code-block:: scala
 
    class MyBlackBox() extends BlackBox{
-     val io = new Bundle{
+     val io = new Bundle {
        val clk       = in  Bool 
        val increment = in  Bool 
        val initValue = in  UInt(8 bits)
@@ -304,7 +306,7 @@ If you want to use only ``std_logic_vector`` on your blackbox component, you can
 
      noIoPrefix()
 
-     addTag(noNumericType)  // only std_logic_vector
+     addTag(noNumericType)  // Only std_logic_vector
    }
 
 The code above will generate the following VHDL:

--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -9,7 +9,7 @@ Clock domains
 Introduction
 ------------
 
-In *SpinalHDL*\ , clock and reset signals can be combined to create a **clock domain**. Clock domains can be applied to some areas of the design and then all synchronous elements instantiated into those areas will then **implicitly** use this clock domain.
+In SpinalHDL, clock and reset signals can be combined to create a **clock domain**. Clock domains can be applied to some areas of the design and then all synchronous elements instantiated into those areas will then `implicitly` use this clock domain.
 
 Clock domain application works like a stack, which means that if you are in a given clock domain you can still apply another clock domain locally.
 
@@ -44,7 +44,7 @@ This definition takes five parameters:
      - Clock signal that defines the domain
      - 
    * - ``reset``
-     - Reset signal. If a register which needs a reset and the clock domain doesn't provide one, an error message will be displayed
+     - Reset signal. If a register exists which needs a reset and the clock domain doesn't provide one, an error message will be displayed
      - null
    * - ``softReset``
      - Reset which infers an additional synchronous reset
@@ -68,17 +68,17 @@ An applied example to define a specific clock domain within the design is as fol
    val coreReset = Bool
 
    // Define a new clock domain
-   val coreClockDomain = ClockDomain(coreClock,coreReset)
+   val coreClockDomain = ClockDomain(coreClock, coreReset)
 
    // Use this domain in an area of the design
-   val coreArea = new ClockingArea(coreClockDomain){
+   val coreArea = new ClockingArea(coreClockDomain) {
      val coreClockedRegister = Reg(UInt(4 bit))
    }
 
 Configuration
 ^^^^^^^^^^^^^
 
-In addition to the constructor parameters given :ref:`here <clock_domain_instantiation>`\ , the following elements of each clock domain are configurable via a ``ClockDomainConfig``\ class:
+In addition to :ref:`constructor parameters <clock_domain_instantiation>`\ , the following elements of each clock domain are configurable via a ``ClockDomainConfig``\ class:
 
 .. list-table::
    :header-rows: 1
@@ -89,7 +89,7 @@ In addition to the constructor parameters given :ref:`here <clock_domain_instant
    * - ``clockEdge``
      - ``RISING``\ , ``FALLING``
    * - ``resetKind``
-     - ``ASYNC``\ , ``SYNC``\ , ``BOOT`` which is supported by some FPGAs (where FF values loaded by the bitstream)
+     - ``ASYNC``\ , ``SYNC``\ , and ``BOOT`` which is supported by some FPGAs (where FF values are loaded by the bitstream)
    * - ``resetActiveLevel``
      - ``HIGH``\ , ``LOW``
    * - ``softResetActiveLevel``
@@ -107,7 +107,7 @@ In addition to the constructor parameters given :ref:`here <clock_domain_instant
        val result = out UInt (4 bits)
      }
 
-     // configure the clock domain 
+     // Configure the clock domain
      val myClockDomain = ClockDomain(
        clock  = io.clk,
        reset  = io.resetn,
@@ -128,12 +128,22 @@ In addition to the constructor parameters given :ref:`here <clock_domain_instant
      }
    }
 
-By default, a ClockDomain is applied to the whole design. The configuration of this one is :
+By default, a ``ClockDomain`` is applied to the whole design. The configuration of this default domain is:
 
 
 * Clock : rising edge
 * Reset : asynchronous, active high
 * No clock enable
+
+This corresponds to the following ``ClockDomainConfig``:
+
+.. code-block:: scala
+
+   val defaultCC = ClockDomainConfig(
+     clockEdge        = RISING,
+     resetKind        = ASYNC,
+     resetActiveLevel = HIGH
+   )
 
 Internal clock
 ^^^^^^^^^^^^^^
@@ -161,7 +171,7 @@ This definition takes six parameters:
      - Description
      - Default
    * - ``name``
-     - Name of clk and reset signal
+     - Name of `clk` and `reset` signal
      - 
    * - ``config``
      - Specify polarity of signals and the nature of the reset
@@ -180,7 +190,9 @@ This definition takes six parameters:
      - UnknownFrequency
 
 
-Its advantage is to create clock and reset signals with a specified name instead of an inherited one. Then you have to assign those ``ClockDomain``'s signals as shown in the example below:
+The advantage of this approach is to create clock and reset signals with a known/specified name instead of an inherited one.
+
+Once created, you have to assign the ``ClockDomain``'s signals, as shown in the example below:
 
 .. code-block:: scala
 
@@ -194,7 +206,7 @@ Its advantage is to create clock and reset signals with a specified name instead
      // myClockDomain.reset will be named myClockName_reset
      val myClockDomain = ClockDomain.internal("myClockName")
 
-     // Instanciate a PLL (probably a BlackBox)
+     // Instantiate a PLL (probably a BlackBox)
      val pll = new Pll()
      pll.io.clkIn := io.clk100M
 
@@ -203,7 +215,7 @@ Its advantage is to create clock and reset signals with a specified name instead
      myClockDomain.reset := io.aReset || !pll.io.
 
      // Do whatever you want with myClockDomain
-     val myArea = new ClockingArea(myClockDomain){
+     val myArea = new ClockingArea(myClockDomain) {
        val myReg = Reg(UInt(4 bits)) init(7)
        myReg := myReg + 1
 
@@ -214,7 +226,7 @@ Its advantage is to create clock and reset signals with a specified name instead
 External clock
 ^^^^^^^^^^^^^^
 
-You can define a clock domain which is driven by the outside anywhere in your source. It will then automatically add clock and reset wire from the top level inputs to all synchronous elements.
+You can define a clock domain which is driven by the outside anywhere in your source. It will then automatically add clock and reset wires from the top level inputs to all synchronous elements.
 
 .. code-block:: scala
 
@@ -227,7 +239,7 @@ You can define a clock domain which is driven by the outside anywhere in your so
      [frequency: IClockDomainFrequency]
    )
 
-The arguments to the ``ClockDomain.external`` function are exactly the same as in the ``ClockDomain.internal`` function. Below an example of a design using ``ClockDomain.external``.
+The arguments to the ``ClockDomain.external`` function are exactly the same as in the ``ClockDomain.internal`` function. Below is an example of a design using ``ClockDomain.external``:
 
 .. code-block:: scala
 
@@ -236,11 +248,11 @@ The arguments to the ``ClockDomain.external`` function are exactly the same as i
        val result = out UInt (4 bits)
      }
 
-     // On top level you have two signals  :
+     // On the top level you have two signals  :
      //     myClockName_clk and myClockName_reset
      val myClockDomain = ClockDomain.external("myClockName")
 
-     val myArea = new ClockingArea(myClockDomain){
+     val myArea = new ClockingArea(myClockDomain) {
        val myReg = Reg(UInt(4 bits)) init(7)
        myReg := myReg + 1
 
@@ -269,28 +281,28 @@ The returned ``ClockDomain`` instance has the following functions that can be ca
      - Return if the clock domain has a reset signal
      - Boolean
    * - hasSoftReset
-     - Return if the clock domain has a reset signal
+     - Return if the clock domain has a soft reset signal
      - Boolean
    * - hasClockEnable
      - Return if the clock domain has a clock enable signal
      - Boolean
    * - readClockWire
-     - Return a signal derived by the clock signal
+     - Return a signal derived from the clock signal
      - Bool
    * - readResetWire
-     - Return a signal derived by the reset signal
+     - Return a signal derived from the soft reset signal
      - Bool
    * - readSoftResetWire
-     - Return a signal derived by the reset signal
+     - Return a signal derived from the reset signal
      - Bool
    * - readClockEnableWire
-     - Return a signal derived by the clock enable signal
+     - Return a signal derived from the clock enable signal
      - Bool
    * - isResetActive
      - Return True when the reset is active
      - Bool
    * - isSoftResetActive
-     - Return True when the softReset is active
+     - Return True when the soft reset is active
      - Bool
    * - isClockEnableActive
      - Return True when the clock enable is active
@@ -303,7 +315,7 @@ An example is included below where a UART controller uses the frequency specific
 
    val coreClockDomain = ClockDomain(coreClock, coreReset, frequency=FixedFrequency(100e6))
 
-   val coreArea = new ClockingArea(coreClockDomain){
+   val coreArea = new ClockingArea(coreClockDomain) {
      val ctrl = new UartCtrl()
      ctrl.io.config.clockDivider := (coreClk.frequency.getValue / 57.6e3 / 8).toInt
    }
@@ -311,7 +323,7 @@ An example is included below where a UART controller uses the frequency specific
 Clock domain crossing
 ---------------------
 
-SpinalHDL checks at compile time that there is no unwanted/unspecified cross clock domain signal reads. If you want to read a signal that is emitted by another ``ClockDomain`` area, you should add the ``crossClockDomain`` tag to the destination signal as depicted in the following example:
+SpinalHDL checks at compile time that there are no unwanted/unspecified cross clock domain signal reads. If you want to read a signal that is emitted by another ``ClockDomain`` area, you should add the ``crossClockDomain`` tag to the destination signal as depicted in the following example:
 
 .. code-block:: scala
 
@@ -324,7 +336,7 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
 
 
 
-   // Implementation where clock and reset pins are given by components IO
+   // Implementation where clock and reset pins are given by components' IO
    class CrossingExample extends Component {
      val io = new Bundle {
        val clkA = in Bool
@@ -338,12 +350,12 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
      }
 
      // sample dataIn with clkA
-     val area_clkA = new ClockingArea(ClockDomain(io.clkA,io.rstA)){  
+     val area_clkA = new ClockingArea(ClockDomain(io.clkA,io.rstA)) {
        val reg = RegNext(io.dataIn) init(False)
      }
 
      // 2 register stages to avoid metastability issues
-     val area_clkB = new ClockingArea(ClockDomain(io.clkB,io.rstB)){  
+     val area_clkB = new ClockingArea(ClockDomain(io.clkB,io.rstB)) {
        val buf0   = RegNext(area_clkA.reg) init(False) addTag(crossClockDomain)
        val buf1   = RegNext(buf0)          init(False)
      }
@@ -352,7 +364,7 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
    }
 
 
-   //Alternative implementation where clock domains are given as parameters
+   // Alternative implementation where clock domains are given as parameters
    class CrossingExample(clkA : ClockDomain,clkB : ClockDomain) extends Component {
      val io = new Bundle {
        val dataIn  = in Bool
@@ -360,12 +372,12 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
      }
 
      // sample dataIn with clkA
-     val area_clkA = new ClockingArea(clkA){  
+     val area_clkA = new ClockingArea(clkA) {
        val reg = RegNext(io.dataIn) init(False)
      }
 
      // 2 register stages to avoid metastability issues
-     val area_clkB = new ClockingArea(clkB){  
+     val area_clkB = new ClockingArea(clkB) {
        val buf0   = RegNext(area_clkA.reg) init(False) addTag(crossClockDomain)
        val buf1   = RegNext(buf0)          init(False)
      }
@@ -373,7 +385,7 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
      io.dataOut := area_clkB.buf1
    }
 
-In general you can use 2 or more flip-flop driven by the destination clock domain to prevent metastability. The ``BufferCC(input: T, init: T = null, bufferDepth: Int = 2)`` function provided in ``spinal.lib._`` will instantiate the necessary flip-flop (the number of flip flop will depends on the bufferDepth) to mitigate the phenomena.
+In general, you can use 2 or more flip-flop driven by the destination clock domain to prevent metastability. The ``BufferCC(input: T, init: T = null, bufferDepth: Int = 2)`` function provided in ``spinal.lib._`` will instantiate the necessary flip-flops (the number of flip-flops will depends on the ``bufferDepth`` parameter) to mitigate the phenomena.
 
 .. code-block:: scala
 
@@ -384,12 +396,12 @@ In general you can use 2 or more flip-flop driven by the destination clock domai
      }
 
      // sample dataIn with clkA
-     val area_clkA = new ClockingArea(clkA){  
+     val area_clkA = new ClockingArea(clkA) {
        val reg = RegNext(io.dataIn) init(False)
      }
 
      // BufferCC to avoid metastability issues
-     val area_clkB = new ClockingArea(clkB){  
+     val area_clkB = new ClockingArea(clkB) {
        val buf1   = BufferCC(area_clkA.reg, False)
      }
 
@@ -397,7 +409,7 @@ In general you can use 2 or more flip-flop driven by the destination clock domai
    }
 
 .. warning::
-   The BufferCC is only for signal Bit, or Bits with Gray-coded(Only 1 bit flip per clock cycle), Can not used for Multi-bits cross-domain process.
+   The ``BufferCC`` function is only for signals of type ``Bit``, or ``Bits`` operating as Gray-coded counters (only 1 bit-flip per clock cycle), and can not used for multi-bit cross-domain processes.
 
 Special clocking Areas
 ----------------------
@@ -405,24 +417,24 @@ Special clocking Areas
 Slow Area
 ^^^^^^^^^
 
-A ``SlowArea`` is used to create a new clock domain area which is slower than the current one. 
+A ``SlowArea`` is used to create a new clock domain area which is slower than the current one:
 
 .. code-block:: scala
 
    class TopLevel extends Component {
 
-     // Use the current clock domain : 100MHz 
+     // Use the current clock domain : 100MHz
      val areaStd = new Area {    
        val counter = out(CounterFreeRun(16).value)
      }
 
-     // Slow the current clockDomain by 4 : 25 MHz 
-     val areaDiv4 = new SlowArea(4){
+     // Slow the current clockDomain by 4 : 25 MHz
+     val areaDiv4 = new SlowArea(4) {
        val counter = out(CounterFreeRun(16).value)
      }
 
-     // Slow the current clockDomainn to 50MHz 
-     val area50Mhz = new SlowArea(50 MHz){
+     // Slow the current clockDomainn to 50MHz
+     val area50Mhz = new SlowArea(50 MHz) {
        val counter = out(CounterFreeRun(16).value)
      }
    }
@@ -436,7 +448,7 @@ A ``SlowArea`` is used to create a new clock domain area which is slower than th
 ResetArea
 ^^^^^^^^^
 
-A ``ResetArea`` is used to create a new clock domain area where a special reset signal is combined with the current clock domain reset.
+A ``ResetArea`` is used to create a new clock domain area where a special reset signal is combined with the current clock domain reset:
 
 .. code-block:: scala
 
@@ -445,12 +457,12 @@ A ``ResetArea`` is used to create a new clock domain area where a special reset 
      val specialReset = Bool 
 
      // The reset of this area is done with the specialReset signal 
-     val areaRst_1 = new ResetArea(specialReset, false){
+     val areaRst_1 = new ResetArea(specialReset, false) {
        val counter = out(CounterFreeRun(16).value)
      }
 
      // The reset of this area is a combination between the current reset and the specialReset
-     val areaRst_2 = new ResetArea(specialReset, true){
+     val areaRst_2 = new ResetArea(specialReset, true) {
        val counter = out(CounterFreeRun(16).value)
      }
    }
@@ -458,7 +470,7 @@ A ``ResetArea`` is used to create a new clock domain area where a special reset 
 ClockEnableArea
 ^^^^^^^^^^^^^^^
 
-A ``ClockEnableArea`` is used to add an additional clock enable in the current clock domain.
+A ``ClockEnableArea`` is used to add an additional clock enable in the current clock domain:
 
 .. code-block:: scala
 
@@ -467,7 +479,7 @@ A ``ClockEnableArea`` is used to add an additional clock enable in the current c
      val clockEnable = Bool 
 
      // Add a clock enable for this area 
-     val area_1 = new ClockEnableArea(clockEnable){
+     val area_1 = new ClockEnableArea(clockEnable) {
        val counter = out(CounterFreeRun(16).value)
      }
    }

--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -9,7 +9,7 @@ Clock domains
 Introduction
 ------------
 
-In SpinalHDL, clock and reset signals can be combined to create a **clock domain**. Clock domains can be applied to some areas of the design and then all synchronous elements instantiated into those areas will then `implicitly` use this clock domain.
+In SpinalHDL, clock and reset signals can be combined to create a **clock domain**. Clock domains can be applied to some areas of the design and then all synchronous elements instantiated into those areas will then **implicitly** use this clock domain.
 
 Clock domain application works like a stack, which means that if you are in a given clock domain you can still apply another clock domain locally.
 

--- a/source/SpinalHDL/Structuring/components_hierarchy.rst
+++ b/source/SpinalHDL/Structuring/components_hierarchy.rst
@@ -7,42 +7,42 @@ Component and hierarchy
 Introduction
 ------------
 
-Like in VHDL and Verilog, you can define components that can be used to build a design hierarchy.  However, in SpinalHDL, you don't need to bind their ports at instantiation
+Like in VHDL and Verilog, you can define components that can be used to build a design hierarchy. However, in SpinalHDL, you don't need to bind their ports at instantiation:
 
 .. code-block:: scala
 
    class AdderCell extends Component {
-     //Declaring external ports in a Bundle called `io` is recommended
+     // Declaring external ports in a Bundle called `io` is recommended
      val io = new Bundle {
        val a, b, cin = in Bool
        val sum, cout = out Bool
      }
-     //Do some logic
+     // Do some logic
      io.sum := io.a ^ io.b ^ io.cin
      io.cout := (io.a & io.b) | (io.a & io.cin) | (io.b & io.cin)
    }
 
    class Adder(width: Int) extends Component {
      ...
-     //Create 2 AdderCell
+     // Create 2 AdderCell instances
      val cell0 = new AdderCell
      val cell1 = new AdderCell
-     cell1.io.cin := cell0.io.cout   //Connect cout of cell0 to cin of cell1
+     cell1.io.cin := cell0.io.cout   // Connect cout of cell0 to cin of cell1
 
-     // Another example which create an array of ArrayCell
+     // Another example which creates an array of ArrayCell instances
      val cellArray = Array.fill(width)(new AdderCell)
-     cellArray(1).io.cin := cellArray(0).io.cout   //Connect cout of cell(0) to cin of cell(1)
+     cellArray(1).io.cin := cellArray(0).io.cout   // Connect cout of cell(0) to cin of cell(1)
      ...
    }
 
 .. tip::
-   | val io = new Bundle{ ... } :
-   | Declaring external ports in a Bundle called `io` is recommended. If you call your bundle `io`, Spinal will check that all elements are defined as input or output.
+   | ``val io = new Bundle { ... }``
+   | Declaring external ports in a ``Bundle`` called ``io`` is recommended. If you name your bundle ``io``, SpinalHDL will check that all of its elements are defined as inputs or outputs.
 
 Input / output definition
 -------------------------
 
-The syntax to define inputs and outputs is the following:
+The syntax to define inputs and outputs is as follows:
 
 .. list-table::
    :header-rows: 1
@@ -58,37 +58,34 @@ The syntax to define inputs and outputs is the following:
      - Create an input/output of the corresponding type
      - Bits/UInt/SInt
    * - in/out(T)
-     - | For all other data types, you may have to add some brackets
-       | around it. Sorry this is a Scala limitation.
+     - For all other data types, you may have to add some brackets around it. Sorry, this is a Scala limitation.
      - T
    * - master/slave(T)
-     - | This syntax is provided by the `spinal.lib` (If you call your object `slave`,
-       | then call `spinal.lib.slave` instead). T should extend IMasterSlave –
-       | Some documentation is available :ref:`here <interface_eaxample_apb>`.
-       | You may not actually need the brackets, so `master T` is fine as well.
+     - This syntax is provided by the ``spinal.lib`` library (If you annotate your object with the ``slave`` syntax, then import ``spinal.lib.slave`` instead).
+       T should extend ``IMasterSlave`` – Some documentation is available :ref:`here <interface_eaxample_apb>`. You may not actually need the brackets, so ``master T`` is fine as well.
      - T
 
 
 There are some rules to follow with component interconnection:
 
 
-* Components can only read output and input signals of child components
-* Components can read their own output port values (unlike VHDL)
+* Components can only `read` output and input signals of child components.
+* Components can read their own output port values (unlike in VHDL).
 
 .. tip::
-   If for some reason, you need to read signals from far away in the hierarchy (debug, temporal patch) you can do it by using the value returned by `some.where.else.theSignal.pull()`.
+   If for some reason you need to read signals from far away in the hierarchy (such as for debugging or temporal patches), you can do it by using the value returned by ``some.where.else.theSignal.pull()``
 
 Pruned signals
 --------------
 
-SpinalHDL only generates things which are required to drive the outputs of your top level entity (directly or indirectly).
+SpinalHDL only generates things which are directly or indirectly required to drive the outputs of your top-level entity.
 
-All other signals (the useless ones) are removed from the RTL generation and are inserted into a list of pruned signals. You can get this list via the ``printPruned`` and the ``printPrunedIo`` function on the generated ``SpinalReport``.
+All other signals (the useless ones) are removed from the RTL generation and are inserted into a list of pruned signals. You can get this list via the ``printPruned`` and the ``printPrunedIo`` functions on the generated ``SpinalReport`` object:
 
 .. code-block:: scala
 
    class TopLevel extends Component {
-     val io = new Bundle{
+     val io = new Bundle {
        val a,b = in UInt(8 bits)
        val result = out UInt(8 bits)
      }
@@ -101,7 +98,7 @@ All other signals (the useless ones) are removed from the RTL generation and are
      unusedSignal2 := unusedSignal
    }
 
-   object Main{
+   object Main {
      def main(args: Array[String]) {
        SpinalVhdl(new TopLevel).printPruned()
        //This will report :
@@ -110,13 +107,13 @@ All other signals (the useless ones) are removed from the RTL generation and are
      }
    }
 
-If you want to keep a pruned signal into the generated RTL for debug reasons, you can use the ``keep`` function of that signal:
+If you want to keep a pruned signal in the generated RTL for debugging reasons, you can use the ``keep`` function of that signal:
 
 .. code-block:: scala
 
    class TopLevel extends Component {
-     val io = new Bundle{
-       val a,b = in UInt(8 bits)
+     val io = new Bundle {
+       val a, b = in UInt(8 bits)
        val result = out UInt(8 bits)
      }
 
@@ -129,10 +126,10 @@ If you want to keep a pruned signal into the generated RTL for debug reasons, yo
      unusedSignal2 := unusedSignal
    }
 
-   object Main{
+   object Main {
      def main(args: Array[String]) {
        SpinalVhdl(new TopLevel).printPruned()
-       //This will report nothing
+       // This will report nothing
      }
    }
 
@@ -144,20 +141,20 @@ If you want to parameterize your component, you can give parameters to the const
 .. code-block:: scala
 
    class MyAdder(width: BitCount) extends Component {
-     val io = new Bundle{
-       val a,b    = in UInt(width)
+     val io = new Bundle {
+       val a, b   = in UInt(width)
        val result = out UInt(width)
      }
      io.result := io.a + io.b
    }
 
-   object Main{
+   object Main {
      def main(args: Array[String]) {
        SpinalVhdl(new MyAdder(32 bits))
      }
    }
 
-I you have several parameters, it is a good practice to give a specific configuration class as follows:
+If you have several parameters, it is a good practice to give a specific configuration class as follows:
 
 .. code-block:: scala
 
@@ -167,19 +164,19 @@ I you have several parameters, it is a good practice to give a specific configur
                           iCache        : InstructionCacheConfig)
 
    class MySoc(config: MySocConfig) extends Component {
-       ...
+     ...
    }
 
 Synthesized component names
 ---------------------------
 
-Within a module, each component has a name, called "partial name".
-The "full" name is built by joining every component's parent name with "_", for example: `io_clockDomain_reset`.
-You can use `setName` to replace this convention with a custom name.
+Within a module, each component has a name, called a "partial name".
+The "full" name is built by joining every component's parent name with "_", for example: ``io_clockDomain_reset``.
+You can use ``setName`` to replace this convention with a custom name.
 This is especially useful when interfacing with external components.
-The other methods are called `getName`, `setPartialName`, `getPartialName` respectively.
+The other methods are called ``getName``, ``setPartialName``, and ``getPartialName`` respectively.
 
-When synthesized, each module gets the name of the Scala class defining it. You can override this as well with `setDefinitionName`.
+When synthesized, each module gets the name of the Scala class defining it. You can override this as well with ``setDefinitionName``.
 
 .. raw:: html
 

--- a/source/SpinalHDL/Structuring/components_hierarchy.rst
+++ b/source/SpinalHDL/Structuring/components_hierarchy.rst
@@ -69,7 +69,7 @@ The syntax to define inputs and outputs is as follows:
 There are some rules to follow with component interconnection:
 
 
-* Components can only `read` output and input signals of child components.
+* Components can only **read** output and input signals of child components.
 * Components can read their own output port values (unlike in VHDL).
 
 .. tip::

--- a/source/SpinalHDL/Structuring/function.rst
+++ b/source/SpinalHDL/Structuring/function.rst
@@ -11,25 +11,23 @@ Introduction
 
 The ways you can use Scala functions to generate hardware are radically different than VHDL/Verilog for many reasons:
 
-
-* You can instantiate registers, combinatorial logic and components inside them.
-* You don't have to play with ``process``\ /\ ``@always`` that limit the scope of assignment of signals
+* You can instantiate registers, combinational logic, and components inside them.
+* You don't have to play with ``process``\ /\ ``@always`` blocks that limit the scope of assignment of signals.
 * | Everything is passed by reference, which allows easy manipulation.
-  | For example you can give a bus to a function as an argument, then the function can internaly read/write to it.
-  | You can also return a Component, a Bus, or anything else from scala and the scala world.
+  | For example, you can give a bus to a function as an argument, then the function can internaly read/write to it. You can also return a Component, a Bus, or anything else from Scala and the Scala world.
 
 RGB to gray
 -----------
 
-For example if you want to convert a Red/Green/Blue color into greyscale by using coefficients, you can use functions to apply them:
+For example, if you want to convert a Red/Green/Blue color into greyscale by using coefficients, you can use functions to apply them:
 
 .. code-block:: scala
 
    // Input RGB color
    val r, g, b = UInt(8 bits)
 
-   // Define a function to multiply a UInt by a scala Float value.
-   def coef(value: UInt, by: Float): UInt = (value * U((255*by).toInt, 8 bits) >> 8)
+   // Define a function to multiply a UInt by a Scala Float value.
+   def coef(value: UInt, by: Float): UInt = (value * U((255 * by).toInt, 8 bits) >> 8)
 
    // Calculate the gray level
    val gray = coef(r, 0.3f) + coef(g, 0.4f) + coef(b, 0.3f)
@@ -37,7 +35,7 @@ For example if you want to convert a Red/Green/Blue color into greyscale by usin
 Valid Ready Payload bus
 -----------------------
 
-For instance if you define a simple Valid Ready Payload bus, you can then define some useful functions inside of it.
+For instance, if you define a simple bus with ``valid``, ``ready``, and ``payload`` signals, you can then define some useful functions inside of it.
 
 .. code-block:: scala
 
@@ -46,7 +44,7 @@ For instance if you define a simple Valid Ready Payload bus, you can then define
      val ready   = Bool
      val payload = Bits(payloadWidth bits)
 
-     // define the direction of the data in a master mode 
+     // Define the direction of the data in a master mode
      override des asMaster(): Unit = {
        out(valid, payload)
        in(ready)


### PR DESCRIPTION
This PR includes spelling/grammar/formatting fixes, as well as the
following:

 - `addPrePostTask` on the blackboxing page is now updated to be
   `addPrePopTask`, along with some explanatory text.