### PR TITLE
Copyedits for the Design Errors section.

### DIFF
--- a/source/SpinalHDL/Design errors/assignment_overlap.rst
+++ b/source/SpinalHDL/Design errors/assignment_overlap.rst
@@ -1,11 +1,11 @@
 
-Assignement overlap
-===================
+Assignment overlap
+==================
 
 Introduction
 ------------
 
-SpinalHDL will check that no signal assignement completely erases a previous one.
+SpinalHDL will check that no signal assignment completely erases a previous one.
 
 Example
 -------
@@ -17,7 +17,7 @@ The following code
    class TopLevel extends Component {
      val a = UInt(8 bits)
      a := 42
-     a := 66 //Erease the a := 42 :(
+     a := 66 // Erase the a := 42 assignment
    }
 
 will throw the following error:
@@ -26,7 +26,7 @@ will throw the following error:
 
    ASSIGNMENT OVERLAP completely the previous one of (toplevel/a :  UInt[8 bits])
      ***
-     Source file location of the a := 66 assignement via the stack trace
+     Source file location of the a := 66 assignment via the stack trace
      ***
 
 A fix could be:
@@ -36,12 +36,12 @@ A fix could be:
    class TopLevel extends Component {
      val a = UInt(8 bits)
      a := 42
-     when(something){
+     when(something) {
        a := 66
      }
    }
 
-But in the case you really want to override the previous assignement (Yes, it could make sense in some cases), you can do the following:
+But in the case when you really want to override the previous assignment (as there are times when overriding makes sense), you can do the following:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Design errors/clock_crossing_violation.rst
+++ b/source/SpinalHDL/Design errors/clock_crossing_violation.rst
@@ -5,7 +5,7 @@ Clock crossing violation
 Introduction
 ------------
 
-SpinalHDL will check that every register of your design only depends (through some combinatorial logic) on registers which use the same or a synchronous clock domain.
+SpinalHDL will check that every register of your design only depends (through combinational logic paths) on registers which use the same or a synchronous clock domain.
 
 Example
 -------
@@ -18,10 +18,10 @@ The following code:
      val clkA = ClockDomain.external("clkA")
      val clkB = ClockDomain.external("clkB")
 
-     val regA = clkA(Reg(UInt(8 bits)))   //PlayDev.scala:834
-     val regB = clkB(Reg(UInt(8 bits)))   //PlayDev.scala:835
+     val regA = clkA(Reg(UInt(8 bits)))   // PlayDev.scala:834
+     val regB = clkB(Reg(UInt(8 bits)))   // PlayDev.scala:835
 
-     val tmp = regA + regA                //PlayDev.scala:838
+     val tmp = regA + regA                // PlayDev.scala:838
      regB := tmp
    }
 
@@ -39,12 +39,18 @@ will throw:
          >>> (toplevel/tmp :  UInt[8 bits]) at ***(PlayDev.scala:838) >>>
          >>> (toplevel/regB :  UInt[8 bits]) at ***(PlayDev.scala:835) >>>
 
-There are multiple possible fixes:
+There are multiple possible fixes, listed below:
+
+ - :ref:`crossClockDomain tags <crossclockdomain-tag>`
+ - :ref:`setSyncronousWith method <setsynchronouswith>`
+ - :ref:`BufferCC type <buffercc>`
+
+.. _crossclockdomain-tag:
 
 crossClockDomain tag
 ^^^^^^^^^^^^^^^^^^^^
 
-The crossClockDomain tag can be used to say "It's alright, don't panic" to SpinalHDL
+The ``crossClockDomain`` tag can be used to communicate "It's alright, don't panic about this specific clock crossing" to the SpinalHDL compiler.
 
 .. code-block:: scala
 
@@ -60,10 +66,12 @@ The crossClockDomain tag can be used to say "It's alright, don't panic" to Spina
      regB := tmp
    }
 
+.. _setsynchronouswith:
+
 setSyncronousWith
 ^^^^^^^^^^^^^^^^^
 
-You can also specify that two clock domains are syncronous together.
+You can also specify that two clock domains are synchronous together by using the ``setSynchronousWith`` method of one of the ``ClockDomain`` objects.
 
 .. code-block:: scala
 
@@ -80,10 +88,16 @@ You can also specify that two clock domains are syncronous together.
      regB := tmp
    }
 
+.. _buffercc:
+
 BufferCC
 ^^^^^^^^
 
-Signal Bits or Gray-coded Bits can use BufferCC to cross different clockDomain 
+When exchanging single-bit signals (such as ``Bool`` types), or Gray-coded values, you can use ``BufferCC`` to safely cross different ``ClockDomain`` regions.
+
+.. warning::
+   Do not use ``BufferCC`` with multi-bit signals, as there is a risk of corrupted reads on the receiving side if the clocks are asynchronous.
+   See the :ref:`Clock Domains <clock_domain>` page for more details.
 
 .. code-block:: scala
 
@@ -107,6 +121,3 @@ Signal Bits or Gray-coded Bits can use BufferCC to cross different clockDomain
         ...
       }
    }
-
-.. warning::
-   Do not use BufferCC for general multi-Bits cross-domain process as mentioned under :ref:`Clock Domains <clock_domain>`  

--- a/source/SpinalHDL/Design errors/combinatorial_loop.rst
+++ b/source/SpinalHDL/Design errors/combinatorial_loop.rst
@@ -1,5 +1,5 @@
 
-Combinational loop
+Combinatorial loop
 ==================
 
 Introduction
@@ -15,8 +15,8 @@ The following code:
 .. code-block:: scala
 
    class TopLevel extends Component {
-     val a = UInt(8 bits) //PlayDev.scala line 831
-     val b = UInt(8 bits) //PlayDev.scala line 832
+     val a = UInt(8 bits) // PlayDev.scala line 831
+     val b = UInt(8 bits) // PlayDev.scala line 832
      val c = UInt(8 bits)
      val d = UInt(8 bits)
 
@@ -49,8 +49,8 @@ A possible fix could be:
 .. code-block:: scala
 
    class TopLevel extends Component {
-     val a = UInt(8 bits) //PlayDev.scala line 831
-     val b = UInt(8 bits) //PlayDev.scala line 832
+     val a = UInt(8 bits) // PlayDev.scala line 831
+     val b = UInt(8 bits) // PlayDev.scala line 832
      val c = UInt(8 bits)
      val d = UInt(8 bits)
 
@@ -60,17 +60,18 @@ A possible fix could be:
      c := 0
    }
 
-False-positive
---------------
+False-positives
+---------------
 
-It should be said that SpinalHDL's algorithm to detect combinatorial loops can be pessimistic, and it may give false positives. If it is giving a false positive, you can manualy disable loop checking on one signal of the loop like so:
+It should be said that SpinalHDL's algorithm to detect combinatorial loops can be pessimistic, and it may give false positives.
+If it is giving a false positive, you can manually disable loop checking on one signal of the loop like so:
 
 .. code-block:: scala
 
    class TopLevel extends Component {
      val a = UInt(8 bits)
      a := 0
-     a(1) := a(0) //False positive because of this line
+     a(1) := a(0) // False positive because of this line
    }
 
 could be fixed by :
@@ -83,4 +84,5 @@ could be fixed by :
      a(1) := a(0)
    }
 
-It should also be said that assignments such as (a(1) := a(0)) can make some tools like Verilator unhappy. It may be better to use a Vec(Bool, 8) in this case.
+It should also be said that assignments such as ``(a(1) := a(0))`` can make some tools like `Verilator <https://www.veripool.org/wiki/verilator>`_ unhappy.
+It may be better to use a ``Vec(Bool, 8)`` in this case.

--- a/source/SpinalHDL/Design errors/hierarchy_violation.rst
+++ b/source/SpinalHDL/Design errors/hierarchy_violation.rst
@@ -9,17 +9,15 @@ SpinalHDL will check that signals are never accessed outside of the current comp
 
 The following signals can be read inside a component:
 
-
 * All directionless signals defined in the current component
 * All in/out/inout signals of the current component
-* All in/out/inout signals of children components
+* All in/out/inout signals of child components
 
-In addition, the following signals can be assigned to inside a component:
-
+In addition, the following signals can be assigned to inside of a component:
 
 * All directionless signals defined in the current component
 * All out/inout signals of the current component
-* All in/inout signals of children components
+* All in/inout signals of child components
 
 If a ``HIERARCHY VIOLATION`` error appears, it means that one of the above rules was violated.
 
@@ -42,7 +40,7 @@ will throw:
 
 .. code-block:: text
 
-   HIERARCHY VIOLATION : (toplevel/io_a : in UInt[8 bits]) is drived by (toplevel/tmp :  UInt[8 bits]), but isn't accessible in the toplevel component.
+   HIERARCHY VIOLATION : (toplevel/io_a : in UInt[8 bits]) is driven by (toplevel/tmp :  UInt[8 bits]), but isn't accessible in the toplevel component.
      ***
      Source file location of the `io.a := tmp` via the stack trace
      ***

--- a/source/SpinalHDL/Design errors/index.rst
+++ b/source/SpinalHDL/Design errors/index.rst
@@ -10,15 +10,19 @@ Design errors
 
 Introduction
 ============
-The SpinalHDL compile will perform many checks on your design to be sure that the generated VHDL/Verilog will be safe for simulation and synthesis. Basicaly, it should not be possible to generate a broken VHDL/Verilog. There is a not exhaustive list of SpinalHDL checks :
 
-* Assignement overlaping
+The SpinalHDL compiler will perform many checks on your design to be sure that the generated VHDL/Verilog will be safe for simulation and synthesis.
+Basically, it should not be possible to generate a broken VHDL/Verilog design.
+Below is a non-exhaustive list of SpinalHDL checks:
+
+* Assignment overlapping
 * Clock crossing
-* Hiearchy violation
+* Hierarchy violation
 * Combinatorial loops
 * Latches
 * Undriven signals
 * Width mismatch
 * Unreachable switch statements
 
-On each SpinalHDL error report, you will find a stack trace which is realy usefull to accuratly find out where the design error is. It could look overkill in a first look, but as soon you start to go futher the traditional way of doing hardware description, it is realy a helpfull tool. 
+On each SpinalHDL error report, you will find a stack trace, which can be useful to accurately find out where the design error is.
+These design checks may look like overkill at first glance, but they becomes invaluable as soon as you start to move away from the traditional way of doing hardware description.

--- a/source/SpinalHDL/Design errors/iobundle.rst
+++ b/source/SpinalHDL/Design errors/iobundle.rst
@@ -5,7 +5,7 @@ Io bundle
 Introduction
 ------------
 
-SpinalHDL will check that each io bundle contains only in/out/inout signals.
+SpinalHDL will check that each ``io`` bundle contains only in/out/inout signals.
 
 Example
 -------
@@ -39,7 +39,7 @@ A fix could be:
      }
    }
 
-But if for meta hardware description reasons you realy want io.a to be directionless, you can do:
+But if for meta hardware description reasons you really want ``io.a`` to be directionless, you can do:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Design errors/latch_detected.rst
+++ b/source/SpinalHDL/Design errors/latch_detected.rst
@@ -5,7 +5,8 @@ Latch detected
 Introduction
 ------------
 
-SpinalHDL will check that no combinatorial signal will infer a latch during synthesis. In other words, that no combinatorial signals are partially assigned.
+SpinalHDL will check that no combinational signals will infer a latch during synthesis.
+In other words, this is a check that no combinational signals are partially assigned.
 
 Example
 -------
@@ -18,7 +19,7 @@ The following code:
      val cond = in(Bool)
      val a = UInt(8 bits)
 
-     when(cond){
+     when(cond) {
        a := 42
      }
    }
@@ -41,7 +42,7 @@ A fix could be:
      val a = UInt(8 bits)
 
      a := 0
-     when(cond){
+     when(cond) {
        a := 42
      }
    }

--- a/source/SpinalHDL/Design errors/no_driver_on.rst
+++ b/source/SpinalHDL/Design errors/no_driver_on.rst
@@ -5,7 +5,7 @@ No driver on
 Introduction
 ------------
 
-SpinalHDL will check that all combinatorial signals which have an impact on the design are assigned by something.
+SpinalHDL will check that all combinational signals which have an impact on the design are assigned by something.
 
 Example
 -------

--- a/source/SpinalHDL/Design errors/nullpointerexception.rst
+++ b/source/SpinalHDL/Design errors/nullpointerexception.rst
@@ -7,7 +7,7 @@ NullPointerException
 Introduction
 ------------
 
-NullPointerException is a Scala runtime reported error which can happen when a variable is accessed before it was initialised.
+``NullPointerException`` is a Scala runtime reported error which can happen when a variable is accessed before it has been initialized.
 
 Example
 -------
@@ -27,7 +27,7 @@ will throw:
 
    Exception in thread "main" java.lang.NullPointerException
      ***
-     Source file location of the a := 42 assignement via the stack trace
+     Source file location of the a := 42 assignment via the stack trace
      ***
 
 A fix could be:
@@ -39,5 +39,9 @@ A fix could be:
      a := 42
    }
 
-| **Issue explanation** :
-| SpinalHDL is not a language, it is a Scala library, which means it obeys the same rules as the Scala general purpose programming language. When you run your SpinalHDL hardware description to generate the corresponding VHDL/Verilog RTL, your SpinalHDL hardware description will be executed as a Scala programm, and ``a`` will be a null reference until the program executes `val a = UInt(8 bits)`, so trying to assign it before then will result in a NullPointerException.
+Issue explanation
+^^^^^^^^^^^^^^^^^
+
+SpinalHDL is not a language, it is a Scala library, which means that it obeys the same rules as the Scala general purpose programming language.
+
+When running the above SpinalHDL hardware description to generate the corresponding VHDL/Verilog RTL, the SpinalHDL hardware description will be executed as a Scala program, and ``a`` will be a null reference until the program executes ``val a = UInt(8 bits)``, so trying to assign to it before then will result in a ``NullPointerException``.

--- a/source/SpinalHDL/Design errors/register_defined_as_component_input.rst
+++ b/source/SpinalHDL/Design errors/register_defined_as_component_input.rst
@@ -5,7 +5,9 @@ Register defined as component input
 Introduction
 ------------
 
-In SpinalHDL, you are not allowed to define a component that has a register as an input. The reasoning behind this is to prevent surprises when the user tries to drive the inputs of child components with the registered signal. If a registered input is desired, you will need to declare the unregistered input in the `io` bundle, and register the signal in the body of the component.
+In SpinalHDL, you are not allowed to define a component that has a register as an input.
+The reasoning behind this is to prevent surprises when the user tries to drive the inputs of child components with the registered signal.
+If a registered input is desired, you will need to declare the unregistered input in the ``io`` bundle, and register the signal in the body of the component.
 
 Example
 -------
@@ -39,7 +41,7 @@ A fix could be :
      }
    }
 
-If a registered `a` is really wanted, it can be done like so:
+If a registered ``a`` is required, it can be done like so:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Design errors/scope_violation.rst
+++ b/source/SpinalHDL/Design errors/scope_violation.rst
@@ -5,7 +5,8 @@ Scope violation
 Introduction
 ------------
 
-SpinalHDL will check that there are no signals assigned outside the scope they are defined in. This error isn't easy to trigger as it requires some specific meta hardware description tricks.
+SpinalHDL will check that there are no signals assigned outside the scope they are defined in.
+This error isn't easy to trigger as it requires some specific meta hardware description tricks.
 
 Example
 -------
@@ -18,7 +19,7 @@ The following code:
      val cond = Bool()
 
      var tmp : UInt = null
-     when(cond){
+     when(cond) {
        tmp = UInt(8 bits)
      }
      tmp := U"x42"
@@ -41,7 +42,7 @@ A fix could be:
      val cond = Bool()
 
      var tmp : UInt = UInt(8 bits)
-     when(cond){
+     when(cond) {
 
      }
      tmp := U"x42"

--- a/source/SpinalHDL/Design errors/spinal_cant_clone.rst
+++ b/source/SpinalHDL/Design errors/spinal_cant_clone.rst
@@ -5,7 +5,8 @@ Spinal can't clone class
 Introduction
 ------------
 
-This error happens when SpinalHDL wants to create a new datatype via the ``cloneOf`` function but isn't able to do it. The reasons for this is nearly always because it can't retreive the construction parameters of a Bundle.
+This error happens when SpinalHDL wants to create a new datatype instance via the ``cloneOf`` function but isn't able to do it.
+The reason for this is nearly always because it can't retreive the construction parameters of a ``Bundle``.
 
 Example
 -------
@@ -14,13 +15,13 @@ The following code:
 
 .. code-block:: scala
 
-    //cloneOf(this) isn't able to retreive the width value that was used to construct itself
-    class RGB(width : Int) extends Bundle{   
-      val r,g,b = UInt(width bits)
+    // cloneOf(this) isn't able to retreive the width value that was used to construct itself
+    class RGB(width : Int) extends Bundle {
+      val r, g, b = UInt(width bits)
     }
 
     class TopLevel extends Component {
-      val tmp = Stream(new RGB(8)) //Stream requires the capability to cloneOf(new RGB(8))
+      val tmp = Stream(new RGB(8)) // Stream requires the capability to cloneOf(new RGB(8))
     }
 
 will throw:
@@ -39,8 +40,8 @@ A fix could be:
 
 .. code-block:: scala
 
-   case class RGB(width : Int) extends Bundle{   
-     val r,g,b = UInt(width bits)
+   case class RGB(width : Int) extends Bundle {
+     val r, g, b = UInt(width bits)
    }
 
    class TopLevel extends Component {

--- a/source/SpinalHDL/Design errors/unassigned_register.rst
+++ b/source/SpinalHDL/Design errors/unassigned_register.rst
@@ -43,7 +43,7 @@ A fix could be:
 Register with only init
 -----------------------
 
-In some cases, because of the design parametrization, it could make sense to generate a register which has no assignment but only a init statement.
+In some cases, because of the design parameterization, it could make sense to generate a register which has no assignment but only an ``init`` statement.
 
 .. code-block:: scala
 
@@ -65,7 +65,7 @@ will throw:
      Source file location of the toplevel/a definition via the stack trace
      ***
 
-To fix it you can ask SpinalHDL to transform the register into a combinatorial one if no assignement is present but it as a init statement:
+To fix it, you can ask SpinalHDL to transform the register into a combinational one if no assignment is present but it has an ``init`` statement:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Design errors/unreachable_is_statement.rst
+++ b/source/SpinalHDL/Design errors/unreachable_is_statement.rst
@@ -5,7 +5,7 @@ Unreachable is statement
 Introduction
 ------------
 
-SpinalHDL will check all `is` statements in a switch are reachable.
+SpinalHDL will check to ensure that all ``is`` statements in a ``switch`` are reachable.
 
 Example
 -------
@@ -17,12 +17,12 @@ The following code:
    class TopLevel extends Component {
      val sel = UInt(2 bits)
      val result = UInt(4 bits)
-     switch(sel){
+     switch(sel) {
        is(0){ result := 4 }
        is(1){ result := 6 }
        is(2){ result := 8 }
        is(3){ result := 9 }
-       is(0){ result := 2 } //Duplicated is statement!
+       is(0){ result := 2 } // Duplicated is statement!
      }
    }
 
@@ -42,7 +42,7 @@ A fix could be:
    class TopLevel extends Component {
      val sel = UInt(2 bits)
      val result = UInt(4 bits)
-     switch(sel){
+     switch(sel) {
        is(0){ result := 4 }
        is(1){ result := 6 }
        is(2){ result := 8 }

--- a/source/SpinalHDL/Design errors/width_mismatch.rst
+++ b/source/SpinalHDL/Design errors/width_mismatch.rst
@@ -5,10 +5,10 @@ Width mismatch
 Introduction
 ------------
 
-SpinalHDL will check that signals on the left and right side of assignments and operators have the same width.
+SpinalHDL will check that operators and signals on the left and right side of assignments have the same widths.
 
-Assignement example
--------------------
+Assignment example
+------------------
 
 The following code:
 


### PR DESCRIPTION
This PR includes spelling/grammar/formatting fixes for the Design
Errors section, as well as the following additional changes:

 - Verilator project link on the "combinatorial loop" page where the
   simulator is mentioned.