### PR TITLE
Copyedits for the Other language features section.

### DIFF
--- a/source/SpinalHDL/Other language features/analog_inout.rst
+++ b/source/SpinalHDL/Other language features/analog_inout.rst
@@ -7,25 +7,28 @@ Analog and inout
 Introduction
 ------------
 
-You can define native tristate signals by using the Analog/inout features. These features were added for the following reasons:
+You can define native tristate signals by using the ``Analog``/``inout`` features.
+These features were added for the following reasons:
 
-* Being able to add native tristate signals to the toplevel (it avoids having to manually wrap them with some hand-written VHDL/Verilog)
-* Allowing the definition of blackboxes which contain inout pins
-* Being able to connect a blackbox's inout pin through the hierarchy to a toplevel inout pin.
+* Being able to add native tristate signals to the toplevel (it avoids having to manually wrap them with some hand-written VHDL/Verilog).
+* Allowing the definition of blackboxes which contain ``inout`` pins.
+* Being able to connect a blackbox's ``inout`` pin through the hierarchy to a toplevel ``inout`` pin.
 
-As those feature were only added for convenience, do not do other fancy stuff with it. If you want to model a component like an memory mapped GPIO peripheral, please use the :ref:`TriState/TriStateArray <section-tristate>` bundles from the spinal lib, which keep the true nature of the tristate driver.
+As those features were only added for convenience, please do not try other fancy stuff with tristate logic just yet.
+
+If you want to model a component like a memory-mapped GPIO peripheral, please use the :ref:`TriState/TriStateArray <section-tristate>` bundles from the Spinal standard library, which abstract over the true nature of tristate drivers.
 
 Analog
 ------
 
-``Analog`` is the keyword which allows a signal to be defined as something ... analog, which in the digital world could mean '0', '1', or 'Z'.
+``Analog`` is the keyword which allows a signal to be defined as something analog, which in the digital world could mean ``0``, ``1``, or ``Z`` (the disconnected, high-impedance state).
 
-For instance :
+For instance:
 
 .. code-block:: scala
 
-   case class SdramInterface(g : SdramLayout) extends Bundle{
-     val DQ    = Analog(Bits(g.dataWidth bits)) //Bidirectional data bus
+   case class SdramInterface(g : SdramLayout) extends Bundle {
+     val DQ    = Analog(Bits(g.dataWidth bits)) // Bidirectional data bus
      val DQM   = Bits(g.bytePerWord bits)
      val ADDR  = Bits(g.chipAddressWidth bits)
      val BA    = Bits(g.bankWidth bits)
@@ -35,35 +38,36 @@ For instance :
 inout
 -----
 
-``inout`` is the keyword which allows you to set an Analog signal as a component inout.
+``inout`` is the keyword which allows you to set an ``Analog`` signal as a bidirectional (both "in" and "out") signal.
 
 For instance:
 
 .. code-block:: scala
 
-   case class SdramInterface(g : SdramLayout) extends Bundle with IMasterSlave{
-     val DQ    = Analog(Bits(g.dataWidth bits)) //Bidirectional data bus
+   case class SdramInterface(g : SdramLayout) extends Bundle with IMasterSlave {
+     val DQ    = Analog(Bits(g.dataWidth bits)) // Bidirectional data bus
      val DQM   = Bits(g.bytePerWord bits)
      val ADDR  = Bits(g.chipAddressWidth bits)
      val BA    = Bits(g.bankWidth bits)
      val CKE, CSn, CASn, RASn, WEn  = Bool
 
      override def asMaster() : Unit = {
-       out(ADDR,BA,CASn,CKE,CSn,DQM,RASn,WEn)
-       inout(DQ) //Set the Analog DQ as an inout of the component
+       out(ADDR, BA, CASn, CKE, CSn, DQM, RASn, WEn)
+       inout(DQ) // Set the Analog DQ as an inout signal of the component
      }
    }
 
 InOutWrapper
 ------------
 
-``InOutWrapper`` is a tool which allows you to tranform all master TriState/TriStateArray/ReadableOpenDrain bundles of a component into native inout(Analog(...)) signals. It allows you to keep all your hardware description without any Analog/inout things, and then transform the toplevel to make it synthesis ready.
+``InOutWrapper`` is a tool which allows you to transform all ``master`` ``TriState``/``TriStateArray``/``ReadableOpenDrain`` bundles of a component into native ``inout(Analog(...))`` signals.
+It allows you to keep your hardware description free of any ``Analog``/``inout`` things, and then transform the toplevel to make it synthesis ready.
 
 For instance:
 
 .. code-block:: scala
 
-   case class Apb3Gpio(gpioWidth : Int) extends Component{
+   case class Apb3Gpio(gpioWidth : Int) extends Component {
      val io = new Bundle{
        val gpio = master(TriStateArray(gpioWidth bits))
        val apb  = slave(Apb3(Apb3Gpio.getApb3Config()))
@@ -79,7 +83,7 @@ Will generate:
 
    entity Apb3Gpio is
      port(
-       io_gpio : inout std_logic_vector(31 downto 0); -- This io_gpio was originaly a TriStateArray Bundle
+       io_gpio : inout std_logic_vector(31 downto 0); -- This io_gpio was originally a TriStateArray Bundle
        io_apb_PADDR : in unsigned(3 downto 0);
        io_apb_PSEL : in std_logic_vector(0 downto 0);
        io_apb_PENABLE : in std_logic;
@@ -118,9 +122,10 @@ Instead of:
 Manually driving Analog bundles
 -------------------------------
 
-If an Analog bundle is not driven, it will default to being high-Z.
-Therefore to manually implement a tristate driver (in case the ``InOutWrapper`` can't be used for some reason) you have to
-conditionally drive the signal. To manually connect a ``TriState`` signal to an Analog bundle:
+If an ``Analog`` bundle is not driven, it will default to being high-Z.
+Therefore to manually implement a tristate driver (in case the ``InOutWrapper`` type can't be used for some reason) you have to conditionally drive the signal.
+
+To manually connect a ``TriState`` signal to an ``Analog`` bundle:
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Other language features/assertion.rst
+++ b/source/SpinalHDL/Other language features/assertion.rst
@@ -2,9 +2,9 @@
 Assertions
 ==========
 
-In addition to scala run-time assertions, you can add hardware assertions using the following syntax:
+In addition to Scala run-time assertions, you can add hardware assertions using the following syntax:
 
-``assert(assertion : Bool,message : String = null,severity: AssertNodeSeverity = Error)``
+``assert(assertion : Bool, message : String = null, severity: AssertNodeSeverity = Error)``
 
 Severity levels are:
 
@@ -15,9 +15,9 @@ Severity levels are:
    * - Name
      - Description
    * - NOTE
-     - Used to report a informative message
+     - Used to report an informative message
    * - WARNING
-     - Used to report a unusual case
+     - Used to report an unusual case
    * - ERROR
      - Used to report an situation that should not happen
    * - FAILURE
@@ -32,14 +32,14 @@ One practical example could be to check that the ``valid`` signal of a handshake
      val valid = RegInit(False)
      val ready = in Bool
 
-     when(ready){
+     when(ready) {
        valid := False
      }
      // some logic
 
      assert(
        assertion = !(valid.fall && !ready),
-       message   = "Valid drop when ready was low",
+       message   = "Valid dropped when ready was low",
        severity  = ERROR
      )
    }

--- a/source/SpinalHDL/Other language features/formal.rst
+++ b/source/SpinalHDL/Other language features/formal.rst
@@ -5,9 +5,9 @@ Formal
 General
 -------
 
-There is limited support for SystemVerilog Assertions.
+There is limited support for SystemVerilog Assertions (SVA).
 
-You can add formal statement (assume, assert ecc..) in the Component definition, like the example below:
+You can add formal statements (assume, assert, etc.) in the ``Component`` definition, like in the example below:
 
 .. code-block:: scala
  
@@ -18,7 +18,7 @@ You can add formal statement (assume, assert ecc..) in the Component definition,
       }
       val valid = RegInit(False)
 
-     when(io.ready){
+     when(io.ready) {
        valid := False
      }
      io.valid <> valid
@@ -27,7 +27,7 @@ You can add formal statement (assume, assert ecc..) in the Component definition,
      import spinal.core.GenerationFlags._
      import spinal.core.Formal._
 
-     GenerationFlags.formal{
+     GenerationFlags.formal {
        when(initstate()) {
          assume(clockDomain.isResetActive)
          assume(io.ready === False)
@@ -41,9 +41,9 @@ To generate a design which includes the formal statements you can use ``includeF
 
 .. code-block:: scala
 
-   object MyToplevelSystemVerilogWithFormal{
+   object MyToplevelSystemVerilogWithFormal {
     def main(args: Array[String]) {
-      val config = SpinalConfig(defaultConfigForClockDomains = ClockDomainConfig(resetKind = SYNC, resetActiveLevel=HIGH))
+      val config = SpinalConfig(defaultConfigForClockDomains = ClockDomainConfig(resetKind=SYNC, resetActiveLevel=HIGH))
        config.includeFormal.generateSystemVerilog(new TopLevel())
      }
    }
@@ -56,34 +56,34 @@ Supported features
 
     * - Syntax
       - Returns
-      - creates in SystemVerilog
-    * - assert()
+      - Creates in SystemVerilog
+    * - ``assert()``
       -
-      - assert()
-    * - cover()
+      - ``assert()``
+    * - ``cover()``
       -
-      - cover()
-    * - | past(that : T, delay : Int)
-        | past(that : T)
+      - ``cover()``
+    * - | ``past(that : T, delay : Int)``
+        | ``past(that : T)``
       - T
-      - past(that)
-    * - rose(that : Bool)
+      - ``past(that)``
+    * - ``rose(that : Bool)``
       - Bool
-      - rose(that)
-    * - fell(that : Bool)
+      - ``rose(that)``
+    * - ``fell(that : Bool)``
       - Bool
       - fell(that)
-    * - changed(that : Bool)
+    * - ``changed(that : Bool)``
       - Bool
-      - changed(that)
-    * - stable(that : Bool)
+      - ``changed(that)``
+    * - ``stable(that : Bool)``
       - Bool
-      - stable(that)
-    * - initstate()
+      - ``stable(that)``
+    * - ``initstate()``
       - Bool
-      - $initstate()
+      - ``$initstate()``
 
 Limitations
 -----------
-No support for unclocked assertions. Everything that is described in 
-``GenerationFlags.formal`` will be generated in a clock process.
+No support for unclocked assertions.
+Everything that is described in ``GenerationFlags.formal`` will be generated in a clocked process.

--- a/source/SpinalHDL/Other language features/index.rst
+++ b/source/SpinalHDL/Other language features/index.rst
@@ -18,19 +18,19 @@ Introduction
 Introduction
 ------------
 
-The core of the language defines the syntax that provides many features :
-
+The core of the language defines the syntax for many features:
 
 * Types / Literals
 * Register / Clock domains
 * Component / Area
 * RAM / ROM
 * When / Switch / Mux
-* BlackBox (to integrate VHDL or Verilog IP inside Spinal)
+* BlackBox (to integrate VHDL or Verilog IPs inside Spinal)
 * SpinalHDL to VHDL converter
 
-Then, by using these features, you can of course define digital hardware, but also build powerful libraries and abstractions. It's one of the major advantages of SpinalHDL over other commonly used HDLs, because you can extend the language without having knowledge about the compiler.
+Then, by using these features, you can define digital hardware, and also build powerful libraries and abstractions.
+It's one of the major advantages of SpinalHDL over other commonly used HDLs, because you can extend the language without having knowledge about the compiler.
 
-One good example of this is the :ref:`SpinalHDL lib <lib_introduction>` which adds many utilities, tools, buses and methodologies.
+One good example of this is the :ref:`SpinalHDL lib <lib_introduction>` which adds many utilities, tools, buses, and methodologies.
 
 To use features introduced in the following chapter you need to ``import spinal.core._`` in your sources.

--- a/source/SpinalHDL/Other language features/utils.rst
+++ b/source/SpinalHDL/Other language features/utils.rst
@@ -9,7 +9,7 @@ Utils
 General
 -------
 
-Many tools and utilities are present in :ref:`spinal.lib <lib_introduction>` but some are already present in SpinalHDL Core.
+Many tools and utilities are present in :ref:`spinal.lib <lib_introduction>` but some are already present in the SpinalHDL Core.
 
 .. list-table::
    :header-rows: 1
@@ -18,19 +18,19 @@ Many tools and utilities are present in :ref:`spinal.lib <lib_introduction>` but
    * - Syntax
      - Return
      - Description
-   * - widthOf(x : BitVector)
+   * - ``widthOf(x : BitVector)``
      - Int
      - Return the width of a Bits/UInt/SInt signal
-   * - log2Up(x : BigInt)
+   * - ``log2Up(x : BigInt)``
      - Int
-     - Return the number of bits needed to represent x states
-   * - isPow2(x : BigInt)
+     - Return the number of bits needed to represent ``x`` states
+   * - ``isPow2(x : BigInt)``
      - Boolean
-     - Return true if x is a power of two
-   * - roundUp(that : BigInt, by : BigInt)
+     - Return true if ``x`` is a power of two
+   * - ``roundUp(that : BigInt, by : BigInt)``
      - BigInt
      - Return the first ``by`` multiply from ``that`` (included)
-   * - Cat(x : Data*)
+   * - ``Cat(x : Data*)``
      - Bits
      - Concatenate all arguments, the first in MSB, the last in LSB
 
@@ -38,39 +38,41 @@ Many tools and utilities are present in :ref:`spinal.lib <lib_introduction>` but
 Cloning hardware datatypes
 --------------------------
 
-You can clone a given hardware data type by using the ``cloneOf(x)`` function. It will return a new instance of the same Scala type and parameters.
+You can clone a given hardware data type by using the ``cloneOf(x)`` function.
+It will return a new instance of the same Scala type and parameters.
 
-For example :
+For example:
 
 .. code-block:: scala
 
    def plusOne(value : UInt) : UInt = {
-     //Will recreate a UInt with the same width than ``value``
+     // Will recreate a UInt with the same width than ``value``
      val temp = cloneOf(value)
      temp := value + 1
      return temp
    }
 
-   //treePlusOne will become a 8 bits value
-   val treePlusOne = plusOne(U(3,8 bits))
+   // treePlusOne will become a 8 bits value
+   val treePlusOne = plusOne(U(3, 8 bits))
 
-You can get more information about how hardware data types are managed :ref:`here <hardware_type>`
+You can get more information about how hardware data types are managed on the :ref:`Hardware types page <hardware_type>`.
 
 .. note::
-   If you use the cloneOf function on a Bundle, this Bundle should be a case class or should override the clone function internally.
+   If you use the ``cloneOf`` function on a ``Bundle``, this ``Bundle`` should be a ``case class`` or should override the clone function internally.
 
 
 Passing a datatype as construction parameter
 --------------------------------------------
 
-Many pieces of reusable hardware need to be parameterized by some data type. For example if you want to define a FIFO or a shift register, you need a parameter to specify which kind of payload you want for the component.
+Many pieces of reusable hardware need to be parameterized by some data type.
+For example if you want to define a FIFO or a shift register, you need a parameter to specify which kind of payload you want for the component.
 
 There are two similar ways to do this.
 
 The old way
 ^^^^^^^^^^^
 
-A good example of the old way to do that is in this definition of a ShiftRegister:
+A good example of the old way to do this is in this definition of a ``ShiftRegister`` component:
 
 .. code-block:: scala
 
@@ -86,9 +88,11 @@ And here is how you can instantiate the component:
 
 .. code-block:: scala
 
-   val shiftReg = ShiftRegister(Bits(32 bits),depth = 8)
+   val shiftReg = ShiftRegister(Bits(32 bits), depth = 8)
 
-As you can see, the raw hardware type is directly passed as a construction parameter. Then each time you want to create an new instance of that kind of hardware data type, you need to use the cloneOf(...) function. Doing things this way is not super safe as it's easy to forget to use cloneOf().
+As you can see, the raw hardware type is directly passed as a construction parameter.
+Then each time you want to create an new instance of that kind of hardware data type, you need to use the ``cloneOf(...)`` function.
+Doing things this way is not super safe as it's easy to forget to use ``cloneOf``.
 
 The safe way
 ^^^^^^^^^^^^
@@ -109,16 +113,17 @@ And here is how you instantiate the component (exactly the same as before):
 
 .. code-block:: scala
 
-   val shiftReg = ShiftRegister(Bits(32 bits),depth = 8)
+   val shiftReg = ShiftRegister(Bits(32 bits), depth = 8)
 
-Notice how the example above uses a HardType wrapper around the raw data type ``T``, which is kind of a blueprint definition of an hardware data type. This way of doing things is easier to use than the "old way", because to create a new instance of the hardware data type you just need to call the ``apply`` function of that HardType (or in other words, just add parentheses after the parameter).
+Notice how the example above uses a ``HardType`` wrapper around the raw data type ``T``, which is a "blueprint" definition of a hardware data type.
+This way of doing things is easier to use than the "old way", because to create a new instance of the hardware data type you only need to call the ``apply`` function of that ``HardType`` (or in other words, just add parentheses after the parameter).
 
-Additionally, this mechanism is completely transparent from the point of view of the user, as a hardware data type can be implicitly converted into an HardType.
+Additionally, this mechanism is completely transparent from the point of view of the user, as a hardware data type can be implicitly converted into a ``HardType``.
 
 Frequency and time
 ------------------
 
-SpinalHDL HDL has a dedicated syntax to defne frequency and time values:
+SpinalHDL has a dedicated syntax to define frequency and time values:
 
 .. code-block:: scala
 
@@ -126,13 +131,13 @@ SpinalHDL HDL has a dedicated syntax to defne frequency and time values:
    val timeoutLimit = 3 ms
    val period = 100 us
 
-   val periodCycles = frequency*period
-   val timeoutCycles = frequency*timeoutLimit
+   val periodCycles = frequency * period
+   val timeoutCycles = frequency * timeoutLimit
 
-| For time definitions you can use following postfixes to get a ``TimeNumber`` :
-| fs, ps, ns, us, ms, sec, mn, hr
+| For time definitions you can use following postfixes to get a ``TimeNumber``:
+| ``fs``, ``ps``, ``ns``, ``us``, ``ms``, ``sec``, ``mn``, ``hr``
 
-| For time definitions you can use following postfixes to get a ``HertzNumber`` :
-| Hz, KHz, MHz, GHz, THz
+| For time definitions you can use following postfixes to get a ``HertzNumber``:
+| ``Hz``, ``KHz``, ``MHz``, ``GHz``, ``THz``
 
-``TimeNumber`` and ``HertzNumber`` are based on the ``PhysicalNumber`` class which uses scala ``BigDecimal`` to store numbers.
+``TimeNumber`` and ``HertzNumber`` are based on the ``PhysicalNumber`` class which uses the Scala ``BigDecimal`` type to store numbers.

--- a/source/SpinalHDL/Other language features/vhdl_generation.rst
+++ b/source/SpinalHDL/Other language features/vhdl_generation.rst
@@ -15,20 +15,20 @@ Generating Verilog is exactly the same, but with ``SpinalVerilog`` in place of `
 
    import spinal.core._
 
-   //A simple component definition
+   // A simple component definition.
    class MyTopLevel extends Component {
-     //Define some input/output. Bundle like a VHDL record or a verilog struct.
+     // Define some input/output signals. Bundle like a VHDL record or a Verilog struct.
      val io = new Bundle {
-       val a = in Bool
-       val b = in Bool
+       val a = in  Bool
+       val b = in  Bool
        val c = out Bool
      }
 
-     //Define some asynchronous logic
+     // Define some asynchronous logic.
      io.c := io.a & io.b
    }
 
-   //This is the main that generates the VHDL and the Verilog corresponding to MyTopLevel
+   // This is the main function that generates the VHDL and the Verilog corresponding to MyTopLevel.
    object MyMain {
      def main(args: Array[String]) {
        SpinalVhdl(new MyTopLevel)
@@ -37,10 +37,13 @@ Generating Verilog is exactly the same, but with ``SpinalVerilog`` in place of `
    }
 
 .. important::
-   SpinalVhdl and SpinalVerilog may need to create multiple instance of your component class, therefore the first argument is not a Component reference but a function that return a new component.
+   ``SpinalVhdl`` and ``SpinalVerilog`` may need to create multiple instances of your component class, therefore the first argument is not a ``Component`` reference, but a function that returns a new component.
 
 .. important::
-   SpinalVerilog implementation began the 5th of June 2016. This backend successfully passes the same regression tests as the VHDL one (RISCV CPU, Multicore and pipelined mandelbrot,UART RX/TX, Single clock fifo, Dual clock fifo, Gray counter, ..). However, if you have any issues with this new backend, please make a git issue describing the problem.
+   The ``SpinalVerilog`` implementation began the 5th of June, 2016.
+   This backend successfully passes the same regression tests as the VHDL one (RISCV CPU, Multicore and pipelined mandelbrot, UART RX/TX, Single clock fifo, Dual clock fifo, Gray counter, ...).
+
+   If you have any issues with this new backend, please make a `Github issue <https://github.com/SpinalHDL/SpinalHDL/issues>`_ describing the problem.
 
 Parametrization from Scala
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -53,41 +56,41 @@ Parametrization from Scala
      - Type
      - Default
      - Description
-   * - mode
+   * - ``mode``
      - SpinalMode
      - null
      - | Set the SpinalHDL hdl generation mode.
        | Can be set to ``VHDL`` or ``Verilog``
-   * - defaultConfigForClockDomains
+   * - ``defaultConfigForClockDomains``
      - ClockDomainConfig
      - | RisingEdgeClock
        | AsynchronousReset
        | ResetActiveHigh
        | ClockEnableActiveHigh
      - Set the clock configuration that will be used as the default value for all new ``ClockDomain``.
-   * - onlyStdLogicVectorAtTopLevelIo
+   * - ``onlyStdLogicVectorAtTopLevelIo``
      - Boolean
      - false
      - Change all unsigned/signed toplevel io into std_logic_vector.
-   * - defaultClockDomainFrequency
+   * - ``defaultClockDomainFrequency``
      - IClockDomainFrequency
      -  UnknownFrequency
-     - Default clock frequency
-   * - targetDirectory
+     - Default clock frequency.
+   * - ``targetDirectory``
      - String
      - Current directory
-     - Directory where files are generated
+     - Directory where files are generated.
 
 
-And here is the syntax to specify them:
+And this is the syntax to specify them:
 
 .. code-block:: scala
 
-   SpinalConfig(mode = VHDL, targetDirectory="temp/myDesign").generate(new UartCtrl)
+   SpinalConfig(mode=VHDL, targetDirectory="temp/myDesign").generate(new UartCtrl)
 
-   // Or for Verilog in a more scalable formatting :
+   // Or for Verilog in a more scalable formatting:
    SpinalConfig(
-     mode = Verilog,
+     mode=Verilog,
      targetDirectory="temp/myDesign"
    ).generate(new UartCtrl)
 
@@ -120,31 +123,28 @@ The syntax for command line arguments is:
 Generated VHDL and Verilog
 --------------------------
 
-The way how a SpinalHDL RTL description is translated into VHDL and Verilog is important :
-
+How a SpinalHDL RTL description is translated into VHDL and Verilog is important:
 
 * Names in Scala are preserved in VHDL and Verilog.
 * ``Component`` hierarchy in Scala is preserved in VHDL and Verilog.
-* ``when`` statements in Scala are emitted as if statements in VHDL and Verilog
-* ``switch`` statements in Scala are emitted as case statements in VHDL and Verilog in all standard cases
+* ``when`` statements in Scala are emitted as if statements in VHDL and Verilog.
+* ``switch`` statements in Scala are emitted as case statements in VHDL and Verilog in all standard cases.
 
 Organization
 ^^^^^^^^^^^^
 
 When you use the VHDL generator, all modules are generated into a single file which contain three sections:
 
-
-#. A package that contains the definition of all Enums 
-#. A package that contains functions used by architectures
+#. A package that contains the definition of all Enums
+#. A package that contains functions used by the architectural elements
 #. All components needed by your design
 
 When you use the Verilog generation, all modules are generated into a single file which contains two sections:
 
-
 #. All enumeration definitions used
 #. All modules needed by your design
 
-Combinatorial logic
+Combinational logic
 ^^^^^^^^^^^^^^^^^^^
 
 Scala:
@@ -154,21 +154,21 @@ Scala:
    class TopLevel extends Component {
      val io = new Bundle {
        val cond           = in  Bool
-       val value          = in  UInt (4 bits)
+       val value          = in  UInt(4 bits)
        val withoutProcess = out UInt(4 bits)
        val withProcess    = out UInt(4 bits)
      }
      io.withoutProcess := io.value
      io.withProcess := 0
-     when(io.cond){
-       switch(io.value){
-         is(U"0000"){
+     when(io.cond) {
+       switch(io.value) {
+         is(U"0000") {
            io.withProcess := 8
          }
-         is(U"0001"){
+         is(U"0001") {
            io.withProcess := 9
          }
-         default{
+         default {
            io.withProcess := io.value+1
          }
        }
@@ -207,7 +207,7 @@ VHDL:
      end process;
    end arch;
 
-Sequential Logic
+Sequential logic
 ^^^^^^^^^^^^^^^^
 
 Scala:
@@ -227,7 +227,7 @@ Scala:
 
      regWithReset := io.value
      regWithoutReset := 0
-     when(io.cond){
+     when(io.cond) {
        regWithoutReset := io.value
      }
 
@@ -280,8 +280,9 @@ VHDL:
 VHDL and Verilog attributes
 ---------------------------
 
-| In some situations, it is useful to give attributes to some signals of a given design to modify synthesis.
-| To do that, you can call the following functions on any signals or memories in the design:
+In some situations, it is useful to give attributes for some signals in a design to modify how they are synthesized.
+
+To do that, you can call the following functions on any signals or memories in the design:
 
 .. list-table::
    :header-rows: 1
@@ -289,9 +290,9 @@ VHDL and Verilog attributes
 
    * - Syntax
      - Description
-   * - addAttribute(name)
+   * - ``addAttribute(name)``
      - Add a boolean attribute with the given ``name`` set to true
-   * - addAttribute(name,value)
+   * - ``addAttribute(name, value)``
      - Add a string attribute with the given ``name`` set to ``value``
 
 


### PR DESCRIPTION
This commit includes spelling/grammar/formatting fixes for the
Other language features section, as well as the following changes:

 - Added link to the Github issue tracker where it was referenced.
 - Multi-sentence lines are broken up into multiple lines now, one
   line per sentence, to help with future diff-tracking.