### PR TITLE
clock_domains.rst: add note about register capture

### DIFF
--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -13,6 +13,8 @@ In SpinalHDL, clock and reset signals can be combined to create a **clock domain
 
 Clock domain application works like a stack, which means that if you are in a given clock domain you can still apply another clock domain locally.
 
+Please note that a register captures its clock domain when the register is created, not when it is assigned. So please make sure to create them inside the desired ``ClockingArea``.
+
 .. _clock_domain_instantiation:
 
 Instantiation


### PR DESCRIPTION
This adds a note about register capture that was not obvious to me even after reading this chapter (https://github.com/SpinalHDL/SpinalHDL/issues/614). 