### PR TITLE
 add 'Signal priorities in HDL generation'

### DIFF
--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -262,6 +262,37 @@ The arguments to the ``ClockDomain.external`` function are exactly the same as i
      }
    }
 
+Signal priorities in HDL generation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In the current version, reset and clock enable signals have different priorities in the same time domain during the code generation phase.Their order is: ``asyncReset``, ``clockEnable``, ``syncReset`` and ``softReset``.
+
+Please be careful that clockEnable has a higher priority than syncReset. If you do a sync reset when the clockEnable is low (especially at the beginning of a simulation), the gated registers will not be reset correctly.
+
+Here is an example:
+
+.. code-block:: scala
+
+  val clockedArea = new ClockEnableArea(clockEnable) {
+    val reg = RegNext(io.input) init False
+  }
+
+It will generate VerilogHDL codes like:
+
+.. code-block:: verilog
+
+  always @(posedge clk) begin
+    if(clockedArea_newClockEnable) begin
+      if(!resetn) begin
+        clockedArea_reg <= 1'b0;
+      end else begin
+        clockedArea_reg <= io_input;
+      end
+    end
+  end
+
+One solution to avoid it is using the Verilog style to insert clock gating cells instead of defining in the clock domain. Or you can wait for the coming improved version of the clock domain class.
+
 Context
 ^^^^^^^
 


### PR DESCRIPTION
Explain the prioirties of reset and clock enable signals in the clock domain class, and a small example is given.