### PR TITLE
Replace "x bit" with "x bits"

### DIFF
--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -400,7 +400,7 @@ Misc
      - Bool
    * - x.expand
      - Return x with 1 bit expand
-     - T(w(x)+1 bit)
+     - T(w(x)+1 bits)
    * - mySInt.absWithSym
      - Return the absolute value of the UInt value with symmetric, shrink 1 bit
      - UInt(w(mySInt) - 1, bits)
@@ -488,7 +488,7 @@ You will find `ROUNDUP`, `ROUNDDOWN`, `ROUNDTOZERO`, `ROUNDTOINF`, `ROUNDTOEVEN`
 
 .. code-block:: scala
 
-   val A  = SInt(16 bit)
+   val A  = SInt(16 bits)
    val B  = A.roundToInf(6 bits) // default 'align = false' with carry, got 11 bit
    val B  = A.roundToInf(6 bits, align = true) // sat 1 carry bit, got 10 bit
    val B  = A.floor(6 bits)             // return 10 bit
@@ -546,7 +546,7 @@ Symmetric is only valid for ``SInt``.
 
 .. code-block:: scala
 
-   val A  = SInt(8 bit)
+   val A  = SInt(8 bits)
    val B  = A.sat(3 bits)      // return 5 bits with saturated highest 3 bits
    val B  = A.sat(3)           // equal to sat(3 bits)
    val B  = A.trim(3 bits)     // return 5 bits with the highest 3 bits discarded
@@ -573,7 +573,7 @@ Factory Fix function with Auto Saturation:
 
 .. code-block:: scala
 
-   val A  = SInt(16 bit)
+   val A  = SInt(16 bits)
    val B  = A.fixTo(10 downto 3) // default RoundType.ROUNDTOINF, sym = false
    val B  = A.fixTo( 8 downto 0, RoundType.ROUNDUP)
    val B  = A.fixTo( 9 downto 3, RoundType.CEIL,       sym = false)

--- a/source/SpinalHDL/Design errors/clock_crossing_violation.rst
+++ b/source/SpinalHDL/Design errors/clock_crossing_violation.rst
@@ -116,7 +116,7 @@ When exchanging single-bit signals (such as ``Bool`` types), or Gray-coded value
       val popCC = new ClockingArea(popClock) {
         val popPtr      = Counter(depth << 1)
         val popPtrGray  = RegNext(toGray(popPtr.valueNext)) init(0)
-        val pushPtrGray = BufferCC(pushToPopGray, B(0, ptrWidth bit))
+        val pushPtrGray = BufferCC(pushToPopGray, B(0, ptrWidth bits))
         val empty       = isEmpty(popPtrGray, pushPtrGray)   
         ...
       }

--- a/source/SpinalHDL/Developers area/bus_slave_factory_impl.rst
+++ b/source/SpinalHDL/Developers area/bus_slave_factory_impl.rst
@@ -215,7 +215,7 @@ Then let's operate the magic to implement all utile based on them :
                    address : BigInt) : Unit  = {
        val wordCount = (widthOf(that) - 1) / busDataWidth + 1
        val valueBits = that.asBits.resize(wordCount*busDataWidth)
-       val words = (0 until wordCount).map(id => valueBits(id * busDataWidth , busDataWidth bit))
+       val words = (0 until wordCount).map(id => valueBits(id * busDataWidth , busDataWidth bits))
        for (wordId <- (0 until wordCount)) {
          read(words(wordId), address + wordId*busDataWidth/8)
        }

--- a/source/SpinalHDL/Developers area/types.rst
+++ b/source/SpinalHDL/Developers area/types.rst
@@ -518,13 +518,13 @@ If you want to define an interface, let's imagine an APB interface, you can also
              selWidth : Int,
              useSlaveError : Boolean) extends Bundle {
 
-     val PADDR      = UInt(addressWidth bit)
+     val PADDR      = UInt(addressWidth bits)
      val PSEL       = Bits(selWidth bits)
      val PENABLE    = Bool
      val PREADY     = Bool
      val PWRITE     = Bool
-     val PWDATA     = Bits(dataWidth bit)
-     val PRDATA     = Bits(dataWidth bit)
+     val PWDATA     = Bits(dataWidth bits)
+     val PRDATA     = Bits(dataWidth bits)
      val PSLVERROR  = if(useSlaveError) Bool() else null   //This wire is created only when useSlaveError is true
    }
 
@@ -546,13 +546,13 @@ Also if one time you need to add another construction parameter, you will only h
                         useSlaveError : Boolean)
 
    class APB(val config: APBConfig) extends Bundle {   //[val] config, make the configuration public
-     val PADDR      = UInt(config.addressWidth bit)
+     val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool
      val PREADY     = Bool
      val PWRITE     = Bool
-     val PWDATA     = Bits(config.dataWidth bit)
-     val PRDATA     = Bits(config.dataWidth bit)
+     val PWDATA     = Bits(config.dataWidth bits)
+     val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool() else null
    }
 
@@ -573,13 +573,13 @@ Then at some points, you will probably need to use the APB bus as master or as s
                         useSlaveError : Boolean)
 
    class APB(val config: APBConfig) extends Bundle {
-     val PADDR      = UInt(config.addressWidth bit)
+     val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool
      val PREADY     = Bool
      val PWRITE     = Bool
-     val PWDATA     = Bits(config.dataWidth bit)
-     val PRDATA     = Bits(config.dataWidth bit)
+     val PWDATA     = Bits(config.dataWidth bits)
+     val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool() else null
 
      def asMaster(): this.type = {
@@ -623,13 +623,13 @@ There is an example of an APB bus that implement this IMasterSlave :
                         useSlaveError : Boolean)
 
    class APB(val config: APBConfig) extends Bundle with IMasterSlave {
-     val PADDR      = UInt(addressWidth bit)
+     val PADDR      = UInt(addressWidth bits)
      val PSEL       = Bits(selWidth bits)
      val PENABLE    = Bool
      val PREADY     = Bool
      val PWRITE     = Bool
-     val PWDATA     = Bits(dataWidth bit)
-     val PRDATA     = Bits(dataWidth bit)
+     val PWDATA     = Bits(dataWidth bits)
+     val PRDATA     = Bits(dataWidth bits)
      val PSLVERROR  = if(useSlaveError) Bool() else null   //This wire is created only when useSlaveError is true
 
      override def asMaster() : Unit = {

--- a/source/SpinalHDL/Examples/Advanced ones/jtag.rst
+++ b/source/SpinalHDL/Examples/Advanced ones/jtag.rst
@@ -29,9 +29,9 @@ The example bellow is a JTAG TAP which allow the JTAG master to read ``switchs``
    class SimpleJtagTap extends Component {
      val io = new Bundle {
        val jtag    = slave(Jtag())
-       val switchs = in  Bits(8 bit)
-       val keys    = in  Bits(4 bit)
-       val leds    = out Bits(8 bit)
+       val switchs = in  Bits(8 bits)
+       val keys    = in  Bits(4 bits)
+       val leds    = out Bits(8 bits)
      }
 
      val tap = new JtagTap(io.jtag, 8)
@@ -117,8 +117,8 @@ Let's implement the core of the JTAG TAP, without any instruction, just the base
 
    class JtagTap(val jtag: Jtag, instructionWidth: Int) extends Area{
      val fsm = new JtagFsm(jtag)
-     val instruction = Reg(Bits(instructionWidth bit))
-     val instructionShift = Reg(Bits(instructionWidth bit))
+     val instruction = Reg(Bits(instructionWidth bits))
+     val instructionShift = Reg(Bits(instructionWidth bits))
      val bypass = Reg(Bool)
 
      jtag.tdo := bypass
@@ -226,7 +226,7 @@ Let's implement an instruction that allow the JTAG to read a signal.
 .. code-block:: scala
 
    class JtagInstructionRead[T <: Data](data: T) (tap: JtagTapAccess,instructionId: Bits)extends JtagInstruction(tap,instructionId) {
-     val shifter = Reg(Bits(data.getBitsWidth bit))
+     val shifter = Reg(Bits(data.getBitsWidth bits))
 
      override def doCapture(): Unit = {
        shifter := data.asBits
@@ -246,7 +246,7 @@ Let's implement an instruction that allow the JTAG to write a register (and also
 .. code-block:: scala
 
    class JtagInstructionWrite[T <: Data](data: T) (tap: JtagTapAccess,instructionId: Bits) extends JtagInstruction(tap,instructionId) {
-     val shifter,store = Reg(Bits(data.getBitsWidth bit))
+     val shifter,store = Reg(Bits(data.getBitsWidth bits))
 
      override def doCapture(): Unit = {
        shifter := store
@@ -270,7 +270,7 @@ Let's implement the instruction that return a idcode to the JTAG and also, when 
 .. code-block:: scala
 
    class JtagInstructionIdcode[T <: Data](value: Bits)(tap: JtagTapAccess, instructionId: Bits)extends JtagInstruction(tap,instructionId) {
-     val shifter = Reg(Bits(32 bit))
+     val shifter = Reg(Bits(32 bits))
 
      override def doShift(): Unit = {
        shifter := (tap.getTdi ## shifter) >> 1
@@ -313,9 +313,9 @@ And there we are, we can now very easily create an application specific JTAG TAP
    class SimpleJtagTap extends Component {
      val io = new Bundle {
        val jtag    = slave(Jtag())
-       val switchs = in  Bits(8 bit)
-       val keys    = in  Bits(4 bit)
-       val leds    = out Bits(8 bit)
+       val switchs = in  Bits(8 bits)
+       val keys    = in  Bits(4 bits)
+       val leds    = out Bits(8 bits)
      }
 
      val tap = new JtagTap(io.jtag, 8)

--- a/source/SpinalHDL/Examples/Intermediates ones/uart.rst
+++ b/source/SpinalHDL/Examples/Intermediates ones/uart.rst
@@ -131,14 +131,14 @@ Let's define ``Bundle``\ s that will be used as IO elements to setup ``UartCtrl`
 .. code-block:: scala
 
    case class UartCtrlFrameConfig(g: UartCtrlGenerics) extends Bundle {
-     val dataLength = UInt(log2Up(g.dataWidthMax) bit) //Bit count = dataLength + 1
+     val dataLength = UInt(log2Up(g.dataWidthMax) bits) //Bit count = dataLength + 1
      val stop       = UartStopType()
      val parity     = UartParityType()
    }
 
    case class UartCtrlConfig(g: UartCtrlGenerics) extends Bundle {
      val frame        = UartCtrlFrameConfig(g)
-     val clockDivider = UInt (g.clockDividerWidth bit) //see UartCtrlGenerics.clockDividerWidth for calculation
+     val clockDivider = UInt (g.clockDividerWidth bits) //see UartCtrlGenerics.clockDividerWidth for calculation
 
      def setClockDivider(baudrate : Double,clkFrequency : Double = ClockDomain.current.frequency.getValue) : Unit = {
        clockDivider := (clkFrequency / baudrate / g.rxSamplePerBit).toInt
@@ -199,7 +199,7 @@ Let's define the skeleton of ``UartCtrlTx``\ :
      val io = new Bundle {
        val configFrame  = in(UartCtrlFrameConfig(g))
        val samplingTick = in Bool()
-       val write        = slave Stream (Bits(dataWidthMax bit))
+       val write        = slave Stream (Bits(dataWidthMax bits))
        val txd          = out Bool
      }
 
@@ -213,7 +213,7 @@ Let's define the skeleton of ``UartCtrlTx``\ :
 
      // Count up each clockDivider.tick, used by the state machine to count up data bits and stop bits
      val tickCounter = new Area {
-       val value = Reg(UInt(Math.max(dataWidthMax, 2) bit))
+       val value = Reg(UInt(Math.max(dataWidthMax, 2) bits))
        def reset() = value := 0
        ..
      }
@@ -243,7 +243,7 @@ And here is the complete implementation:
      val io = new Bundle {
        val configFrame  = in(UartCtrlFrameConfig(g))
        val samplingTick = in Bool
-       val write        = slave Stream (Bits(dataWidthMax bit))
+       val write        = slave Stream (Bits(dataWidthMax bits))
        val txd          = out Bool
      }
 
@@ -260,7 +260,7 @@ And here is the complete implementation:
 
      // Count up each clockDivider.tick, used by the state machine to count up data bits and stop bits
      val tickCounter = new Area {
-       val value = Reg(UInt(Math.max(dataWidthMax, 2) bit))
+       val value = Reg(UInt(Math.max(dataWidthMax, 2) bits))
        def reset() = value := 0
 
        when(clockDivider.tick) {
@@ -371,7 +371,7 @@ Let's define the skeleton of the UartCtrlRx :
      val io = new Bundle {
        val configFrame  = in(UartCtrlFrameConfig(g))
        val samplingTick = in Bool
-       val read         = master Flow (Bits(dataWidthMax bit))
+       val read         = master Flow (Bits(dataWidthMax bits))
        val rxd          = in Bool
      }
 
@@ -387,7 +387,7 @@ Let's define the skeleton of the UartCtrlRx :
      // Provide a bitTimer.tick each rxSamplePerBit
      // reset() can be called to recenter the counter over a start bit.
      val bitTimer = new Area {
-       val counter = Reg(UInt(log2Up(rxSamplePerBit) bit))
+       val counter = Reg(UInt(log2Up(rxSamplePerBit) bits))
        def reset() = counter := preSamplingSize + (samplingSize - 1) / 2 - 1)
        val tick = False
        ...
@@ -396,7 +396,7 @@ Let's define the skeleton of the UartCtrlRx :
      // Provide bitCounter.value that count up each bitTimer.tick, Used by the state machine to count data bits and stop bits
      // reset() can be called to reset it to zero
      val bitCounter = new Area {
-       val value = Reg(UInt(Math.max(dataWidthMax, 2) bit))
+       val value = Reg(UInt(Math.max(dataWidthMax, 2) bits))
        def reset() = value := 0
        ...
      }
@@ -423,7 +423,7 @@ And here is the complete implementation:
      val io = new Bundle {
        val configFrame  = in(UartCtrlFrameConfig(g))
        val samplingTick = in Bool
-       val read         = master Flow (Bits(dataWidthMax bit))
+       val read         = master Flow (Bits(dataWidthMax bits))
        val rxd          = in Bool
      }
 
@@ -439,7 +439,7 @@ And here is the complete implementation:
      // Provide a bitTimer.tick each rxSamplePerBit
      // reset() can be called to recenter the counter over a start bit.
      val bitTimer = new Area {
-       val counter = Reg(UInt(log2Up(rxSamplePerBit) bit))
+       val counter = Reg(UInt(log2Up(rxSamplePerBit) bits))
        def reset() = counter := preSamplingSize + (samplingSize - 1) / 2 - 1
        val tick = False
        when(sampler.tick) {
@@ -453,7 +453,7 @@ And here is the complete implementation:
      // Provide bitCounter.value that count up each bitTimer.tick, Used by the state machine to count data bits and stop bits
      // reset() can be called to reset it to zero
      val bitCounter = new Area {
-       val value = Reg(UInt(Math.max(dataWidthMax, 2) bit))
+       val value = Reg(UInt(Math.max(dataWidthMax, 2) bits))
        def reset() = value := 0
 
        when(bitTimer.tick) {
@@ -538,8 +538,8 @@ Let's write ``UartCtrl`` that instantiates the ``UartCtrlRx`` and ``UartCtrlTx``
    class UartCtrl(g : UartCtrlGenerics = UartCtrlGenerics()) extends Component {
      val io = new Bundle {
        val config = in(UartCtrlConfig(g))
-       val write  = slave(Stream(Bits(g.dataWidthMax bit)))
-       val read   = master(Flow(Bits(g.dataWidthMax bit)))
+       val write  = slave(Stream(Bits(g.dataWidthMax bits)))
+       val read   = master(Flow(Bits(g.dataWidthMax bits)))
        val uart   = master(Uart())
      }
 

--- a/source/SpinalHDL/Examples/Intermediates ones/vga.rst
+++ b/source/SpinalHDL/Examples/Intermediates ones/vga.rst
@@ -30,9 +30,9 @@ First, we need a three channel color structure (Red, Green, Blue). This data str
    }
 
    case class Rgb(c: RgbConfig) extends Bundle{
-     val r = UInt(c.rWidth bit)
-     val g = UInt(c.gWidth bit)
-     val b = UInt(c.bWidth bit)
+     val r = UInt(c.rWidth bits)
+     val g = UInt(c.gWidth bits)
+     val b = UInt(c.bWidth bits)
    }
 
 VGA bus
@@ -103,10 +103,10 @@ Let's write it in a clearer way:
 .. code-block:: scala
 
    case class VgaTimingsHV(timingsWidth: Int) extends Bundle {
-     val colorStart = UInt(timingsWidth bit)
-     val colorEnd   = UInt(timingsWidth bit)
-     val syncStart  = UInt(timingsWidth bit)
-     val syncEnd    = UInt(timingsWidth bit)
+     val colorStart = UInt(timingsWidth bits)
+     val colorEnd   = UInt(timingsWidth bits)
+     val syncStart  = UInt(timingsWidth bits)
+     val syncEnd    = UInt(timingsWidth bits)
    }
 
    case class VgaTimings(timingsWidth: Int) extends Bundle {
@@ -119,10 +119,10 @@ Then we could add some some functions to set these timings for specific resoluti
 .. code-block:: scala
 
    case class VgaTimingsHV(timingsWidth: Int) extends Bundle {
-     val colorStart = UInt(timingsWidth bit)
-     val colorEnd   = UInt(timingsWidth bit)
-     val syncStart  = UInt(timingsWidth bit)
-     val syncEnd    = UInt(timingsWidth bit)
+     val colorStart = UInt(timingsWidth bits)
+     val colorEnd   = UInt(timingsWidth bits)
+     val syncStart  = UInt(timingsWidth bits)
+     val syncEnd    = UInt(timingsWidth bits)
    }
 
    case class VgaTimings(timingsWidth: Int) extends Bundle {
@@ -220,7 +220,7 @@ Let's define ``HVArea``\ , which represents one ~PWM~ and then instantiate it tw
      val io = new Bundle {...}
 
      case class HVArea(timingsHV: VgaTimingsHV, enable: Bool) extends Area {
-       val counter = Reg(UInt(timingsWidth bit)) init(0)
+       val counter = Reg(UInt(timingsWidth bits)) init(0)
 
        val syncStart  = counter === timingsHV.syncStart
        val syncEnd    = counter === timingsHV.syncEnd

--- a/source/SpinalHDL/Examples/Simple ones/apb3.rst
+++ b/source/SpinalHDL/Examples/Simple ones/apb3.rst
@@ -75,13 +75,13 @@ Then we can define the APB3 ``Bundle`` which will be used to represent the bus i
 .. code-block:: scala
 
    case class Apb3(config: Apb3Config) extends Bundle with IMasterSlave {
-     val PADDR      = UInt(config.addressWidth bit)
+     val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool()
      val PREADY     = Bool()
      val PWRITE     = Bool()
-     val PWDATA     = Bits(config.dataWidth bit)
-     val PRDATA     = Bits(config.dataWidth bit)
+     val PWDATA     = Bits(config.dataWidth bits)
+     val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool else null
 
      override def asMaster(): Unit = {

--- a/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_comp.rst
+++ b/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_comp.rst
@@ -97,7 +97,7 @@ For example:
      )
    )
    val coreArea = new ClockingArea(coreClockDomain) {
-     val myCoreClockedRegister = Reg(UInt(4 bit))
+     val myCoreClockedRegister = Reg(UInt(4 bits))
      // ...
      // coreClockDomain will also be applied to all sub components instantiated in the Area
      // ... 

--- a/source/SpinalHDL/Getting Started/Scala Guide/coding_conventions.rst
+++ b/source/SpinalHDL/Getting Started/Scala Guide/coding_conventions.rst
@@ -74,7 +74,7 @@ A function should always start with a lowercase letter:
      S((sinValue * ((1 << resolutionWidth) / 2 - 1)).toInt, resolutionWidth bits)
    })
 
-   val rom =  Mem(SInt(resolutionWidth bit), initialContent = sinTable)
+   val rom =  Mem(SInt(resolutionWidth bits), initialContent = sinTable)
 
 instances
 ^^^^^^^^^
@@ -150,9 +150,9 @@ Grouping parameters of a ``Component``/``Bundle`` inside a case class is general
    }
 
    case class Rgb(c: RgbConfig) extends Bundle {
-     val r = UInt(c.rWidth bit)
-     val g = UInt(c.gWidth bit)
-     val b = UInt(c.bWidth bit)
+     val r = UInt(c.rWidth bits)
+     val g = UInt(c.gWidth bits)
+     val b = UInt(c.bWidth bits)
    }
 
 But this should not be applied in all cases. For example: in a FIFO, it doesn't make sense to group the ``dataType`` parameter with the ``depth`` parameter of the fifo because, in general, the ``dataType`` is something related to the design, while the ``depth`` is something related to the configuration of the design.

--- a/source/SpinalHDL/Libraries/Bus/amba3/apb3.rst
+++ b/source/SpinalHDL/Libraries/Bus/amba3/apb3.rst
@@ -43,13 +43,13 @@ There is in short how the APB3 bus is defined in the SpinalHDL library :
 .. code-block:: scala
 
    case class Apb3(config: Apb3Config) extends Bundle with IMasterSlave {
-     val PADDR      = UInt(config.addressWidth bit)
+     val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool()
      val PREADY     = Bool()
      val PWRITE     = Bool()
-     val PWDATA     = Bits(config.dataWidth bit)
-     val PRDATA     = Bits(config.dataWidth bit)
+     val PWDATA     = Bits(config.dataWidth bits)
+     val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool() else null
      //...
    }

--- a/source/SpinalHDL/Libraries/Graphics/vga.rst
+++ b/source/SpinalHDL/Libraries/Graphics/vga.rst
@@ -29,10 +29,10 @@ VGA timings could be modeled in hardware by using an VgaTimings bundle :
 .. code-block:: scala
 
    case class VgaTimingsHV(timingsWidth: Int) extends Bundle {
-     val colorStart = UInt(timingsWidth bit)
-     val colorEnd = UInt(timingsWidth bit)
-     val syncStart = UInt(timingsWidth bit)
-     val syncEnd = UInt(timingsWidth bit)
+     val colorStart = UInt(timingsWidth bits)
+     val colorEnd = UInt(timingsWidth bits)
+     val syncStart = UInt(timingsWidth bits)
+     val syncEnd = UInt(timingsWidth bits)
    }
 
    case class VgaTimings(timingsWidth: Int) extends Bundle {

--- a/source/SpinalHDL/Libraries/stream.rst
+++ b/source/SpinalHDL/Libraries/stream.rst
@@ -177,9 +177,9 @@ The following code will create this logic :
 .. code-block:: scala
 
    case class RGB(channelWidth : Int) extends Bundle{
-     val red   = UInt(channelWidth bit)
-     val green = UInt(channelWidth bit)
-     val blue  = UInt(channelWidth bit)
+     val red   = UInt(channelWidth bits)
+     val green = UInt(channelWidth bits)
+     val blue  = UInt(channelWidth bits)
 
      def isBlack : Bool = red === 0 && green === 0 && blue === 0
    }

--- a/source/SpinalHDL/Other language features/analog_inout.rst
+++ b/source/SpinalHDL/Other language features/analog_inout.rst
@@ -131,8 +131,8 @@ To manually connect a ``TriState`` signal to an ``Analog`` bundle:
 
     case class Example extends Component {
       val io = new Bundle {
-        val tri = slave(TriState(Bits(16 bit)))
-        val analog = inout(Analog(Bits(16 bit)))
+        val tri = slave(TriState(Bits(16 bits)))
+        val analog = inout(Analog(Bits(16 bits)))
       }
       io.tri.read := io.analog
       when(io.tri.writeEnable) { io.analog := io.tri.write }

--- a/source/SpinalHDL/Other language features/stub.rst
+++ b/source/SpinalHDL/Other language features/stub.rst
@@ -8,8 +8,8 @@ You can emtpy an Component Hierarchy as stub:
 
     class SubSysModule extends Component{
        val io = new Bundle{
-         val dx = slave(Stream(Bits(32 bit)))
-         val dy = master(Stream(Bits(32 bit)))
+         val dx = slave(Stream(Bits(32 bits)))
+         val dy = master(Stream(Bits(32 bits)))
        }
        io.dy <-< io.dx
     }

--- a/source/SpinalHDL/Other language features/vhdl_generation.rst
+++ b/source/SpinalHDL/Other language features/vhdl_generation.rst
@@ -217,9 +217,9 @@ Scala:
    class TopLevel extends Component {
      val io = new Bundle {
        val cond   = in Bool()
-       val value  = in UInt (4 bit)
-       val resultA = out UInt(4 bit)
-       val resultB = out UInt(4 bit)
+       val value  = in UInt (4 bits)
+       val resultA = out UInt(4 bits)
+       val resultB = out UInt(4 bits)
      }
 
      val regWithReset = Reg(UInt(4 bits)) init(0)

--- a/source/SpinalHDL/Semantic/assignments.rst
+++ b/source/SpinalHDL/Semantic/assignments.rst
@@ -47,12 +47,12 @@ It also support Bundle assignment, Bundle multiple signals together use ``()`` t
 .. code-block:: scala
 
    val a, b, c = UInt(4 bits)
-   val d       = UInt(12 bit)
-   val e       = Bits(10 bit)
-   val f       = SInt(2  bit)
+   val d       = UInt(12 bits)
+   val e       = Bits(10 bits)
+   val f       = SInt(2  bits)
    val g       = Bits()
 
-   (a, b, c) := B(0, 12 bit)
+   (a, b, c) := B(0, 12 bits)
    (a, b, c) := d.asBits
    (a, b, c) := (e, f).asBits
    g         := (a, b, c, e, f).asBits

--- a/source/SpinalHDL/Sequential logic/registers.rst
+++ b/source/SpinalHDL/Sequential logic/registers.rst
@@ -42,7 +42,7 @@ Here is an example declaring some registers:
 .. code-block:: scala
 
    // UInt register of 4 bits
-   val reg1 = Reg(UInt(4 bit))
+   val reg1 = Reg(UInt(4 bits))
 
    // Register that samples reg1 each cycle
    val reg2 = RegNext(reg1 + 1)
@@ -89,7 +89,7 @@ you can also set the reset value by calling the ``init(value : Data)`` function 
 .. code-block:: scala
 
    // UInt register of 4 bits initialized with 0 when the reset occurs
-   val reg1 = Reg(UInt(4 bit)) init(0)
+   val reg1 = Reg(UInt(4 bits)) init(0)
 
 If you have a register containing a Bundle, you can use the ``init`` function on each element of the Bundle.
 
@@ -111,7 +111,7 @@ For registers that don't need a reset value in RTL, but need an initialization v
 .. code-block:: scala
 
    // UInt register of 4 bits initialized with a random value
-   val reg1 = Reg(UInt(4 bit)) randBoot()
+   val reg1 = Reg(UInt(4 bits)) randBoot()
 
 Register vectors
 ----------------

--- a/source/SpinalHDL/Structuring/area.rst
+++ b/source/SpinalHDL/Structuring/area.rst
@@ -20,7 +20,7 @@ For this kind of case you can use an ``Area`` to define a group of signals/logic
    class UartCtrl extends Component {
      ...
      val timer = new Area {
-       val counter = Reg(UInt(8 bit))
+       val counter = Reg(UInt(8 bits))
        val tick = counter === 0
        counter := counter - 1
        when(tick) {
@@ -29,7 +29,7 @@ For this kind of case you can use an ``Area`` to define a group of signals/logic
      }
 
      val tickCounter = new Area {
-       val value = Reg(UInt(3 bit))
+       val value = Reg(UInt(3 bits))
        val reset = False
        when(timer.tick) {          // Refer to the tick from timer area
          value := value + 1

--- a/source/SpinalHDL/Structuring/blackbox.rst
+++ b/source/SpinalHDL/Structuring/blackbox.rst
@@ -30,13 +30,13 @@ An example of how to define a blackbox is shown below:
        val clk = in Bool()
        val wr = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(wordCount) bit)
-         val data = in Bits (wordWidth bit)
+         val addr = in UInt (log2Up(wordCount) bits)
+         val data = in Bits (wordWidth bits)
        }
        val rd = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(wordCount) bit)
-         val data = out Bits (wordWidth bit)
+         val addr = in UInt (log2Up(wordCount) bits)
+         val data = out Bits (wordWidth bits)
        }
      }
 
@@ -84,13 +84,13 @@ Instantiating a ``BlackBox`` is just like instantiating a ``Component``:
      val io = new Bundle {    
        val wr = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(16) bit)
-         val data = in Bits (8 bit)
+         val addr = in UInt (log2Up(16) bits)
+         val data = in Bits (8 bits)
        }
        val rd = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(16) bit)
-         val data = out Bits (8 bit)
+         val addr = in UInt (log2Up(16) bits)
+         val data = out Bits (8 bits)
        }
      }
 
@@ -184,13 +184,13 @@ In order to avoid the prefix "io\_" on each of the IOs of the blackbox, you can 
 
        val wr = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(_wordCount) bit)
-         val data = in Bits (_wordWidth bit)
+         val addr = in UInt (log2Up(_wordCount) bits)
+         val data = in Bits (_wordWidth bits)
        }
        val rd = new Bundle {
          val en   = in Bool()
-         val addr = in UInt (log2Up(_wordCount) bit)
-         val data = out Bits (_wordWidth bit)
+         val addr = in UInt (log2Up(_wordCount) bits)
+         val data = out Bits (_wordWidth bits)
        }
      }
 

--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -74,7 +74,7 @@ An applied example to define a specific clock domain within the design is as fol
 
    // Use this domain in an area of the design
    val coreArea = new ClockingArea(coreClockDomain) {
-     val coreClockedRegister = Reg(UInt(4 bit))
+     val coreClockedRegister = Reg(UInt(4 bits))
    }
 
 Configuration

--- a/source/SpinalHDL/Structuring/components_hierarchy.rst
+++ b/source/SpinalHDL/Structuring/components_hierarchy.rst
@@ -54,7 +54,7 @@ The syntax to define inputs and outputs is as follows:
    * - in Bool()/out Bool()
      - Create an input Bool/output Bool
      - Bool
-   * - in/out Bits/UInt/SInt[(x bit)]
+   * - in/out Bits/UInt/SInt[(x bits)]
      - Create an input/output of the corresponding type
      - Bits/UInt/SInt
    * - in/out(T)

--- a/source/SpinalHDL/miscelenea/core/core_components.rst
+++ b/source/SpinalHDL/miscelenea/core/core_components.rst
@@ -63,7 +63,7 @@ An applied example to define a specific clock domain within the design is as fol
 
    // Use this domain in an area of the design
    val coreArea = new ClockingArea(coreClockDomain){
-     val coreClockedRegister = Reg(UInt(4 bit))
+     val coreClockedRegister = Reg(UInt(4 bits))
    }
 
 Clock configuration
@@ -143,10 +143,10 @@ SpinalHDL checks at compile time that there is no unwanted/unspecified cross clo
 
 .. code-block:: scala
 
-   val asynchronousSignal = UInt(8 bit)
+   val asynchronousSignal = UInt(8 bits)
    ...
-   val buffer0 = Reg(UInt(8 bit)).addTag(crossClockDomain)
-   val buffer1 = Reg(UInt(8 bit))
+   val buffer0 = Reg(UInt(8 bits)).addTag(crossClockDomain)
+   val buffer1 = Reg(UInt(8 bits))
    buffer0 := asynchronousSignal
    buffer1 := buffer0   // Second register stage to be avoid metastability issues
 
@@ -181,14 +181,14 @@ There are multiple assignment operator :
 .. code-block:: scala
 
    //Because of hardware concurrency is always read with the value '1' by b and c
-   val a,b,c = UInt(4 bit)
+   val a,b,c = UInt(4 bits)
    a := 0
    b := a
    a := 1  //a := 1 win
    c := a  
 
-   var x = UInt(4 bit)
-   val y,z = UInt(4 bit)
+   var x = UInt(4 bits)
+   val y,z = UInt(4 bits)
    x := 0
    y := x      //y read x with the value 0
    x \= x + 1
@@ -312,7 +312,7 @@ Syntax to define in/out is the following :
    * - in/out Bool
      - Create an input/output Bool
      - Bool
-   * - in/out Bits/UInt/SInt[(x bit)]
+   * - in/out Bits/UInt/SInt[(x bits)]
      - Create an input/output of the corresponding type
      - T
 
@@ -334,7 +334,7 @@ Sometime, creating a component to define some logic is overkill and to much verb
    class UartCtrl extends Component {
      ...
      val timer = new Area {
-       val counter = Reg(UInt(8 bit))
+       val counter = Reg(UInt(8 bits))
        val tick = counter === 0
        counter := counter - 1
        when(tick) {
@@ -342,7 +342,7 @@ Sometime, creating a component to define some logic is overkill and to much verb
        }
      }
      val tickCounter = new Area {
-       val value = Reg(UInt(3 bit))
+       val value = Reg(UInt(3 bits))
        val reset = False
        when(timer.tick) {          // Refer to the tick from timer area
          value := value + 1
@@ -495,13 +495,13 @@ Instanciate VHDL and Verilog IP
 
        val wr = new Bundle {
          val en = in Bool
-         val addr = in UInt (log2Up(_wordCount) bit)
-         val data = in Bits (_wordWidth bit)
+         val addr = in UInt (log2Up(_wordCount) bits)
+         val data = in Bits (_wordWidth bits)
        }
        val rd = new Bundle {
          val en = in Bool
-         val addr = in UInt (log2Up(_wordCount) bit)
-         val data = out Bits (_wordWidth bit)
+         val addr = in UInt (log2Up(_wordCount) bits)
+         val data = out Bits (_wordWidth bits)
        }
      }
 

--- a/source/SpinalHDL/miscelenea/regular_hdl.rst
+++ b/source/SpinalHDL/miscelenea/regular_hdl.rst
@@ -118,13 +118,13 @@ A SpinalHDL APB3 bus definition:
 
    //Class which can be instantiated to represent a given hardware APB3 bus
    case class Apb3(config: Apb3Config) extends Bundle with IMasterSlave {
-     val PADDR      = UInt(config.addressWidth bit)
+     val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool()
      val PREADY     = Bool()
      val PWRITE     = Bool()
-     val PWDATA     = Bits(config.dataWidth bit)
-     val PRDATA     = Bits(config.dataWidth bit)
+     val PWDATA     = Bits(config.dataWidth bits)
+     val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool() else null  //Optional signal
 
      //Can be used to setup a given APB3 bus into a master interface of the host component


### PR DESCRIPTION
A lot of non data type pages still used bit instead of bits like:
UInt(8 bit). Replaced them with s/bit)/bits)/g in all files.

Signed-off-by: Daniel Schultz <dnltz@aesc-silicon.de>