### PR TITLE
regif API update 

### DIFF
--- a/source/SpinalHDL/Libraries/binarySystem.rst
+++ b/source/SpinalHDL/Libraries/binarySystem.rst
@@ -18,7 +18,7 @@ Specification
      - Return
 
    * - **String**.asHex
-     - HexString to BigInt == BigInt(string, 10)
+     - HexString to BigInt == BigInt(string, 16)
      - BigInt
    * - **String**.asDec
      - Decimal String to BigInt == BigInt(string, 10)


### PR DESCRIPTION
documentation for https://github.com/SpinalHDL/SpinalHDL/pull/693

1.  fied(HardType(T))
2. add RALF(UVM Register Abstraction Layer Generator) supported 
3. setName add on RegInst and Field
4. mv lib.bus.regif.Document._ to lib.bus.regif._

please merge  after next SpinalHDL version( >= 1.6.5)  release