### PR TITLE
Fix some minor problems in Libraries and Simulation

### DIFF
--- a/source/SpinalHDL/Libraries/binarySystem.rst
+++ b/source/SpinalHDL/Libraries/binarySystem.rst
@@ -217,7 +217,7 @@ BigInt enricher
 .. code-block:: scala
 
    $: 32.toBigInt
-   34
+   32
    $: 3211323244L.toBigInt
    3211323244
    $: 8.toByte.toBigInt

--- a/source/SpinalHDL/Libraries/regIf.rst
+++ b/source/SpinalHDL/Libraries/regIf.rst
@@ -18,7 +18,7 @@ Automatic address allocation
     val io = new Bundle{
       apb = Apb3(Apb3Config(16,32))
     }
-    val busif = BusInterface(io.apb,(0x0000, 100 Byte)
+    val busif = Apb3BusInterface(io.apb,(0x0000, 100 Byte)
     val M_REG0  = busif.newReg(doc="REG0")
     val M_REG1  = busif.newReg(doc="REG1")
     val M_REG2  = busif.newReg(doc="REG2")
@@ -201,13 +201,15 @@ Manual writing interruption
       val rx_int_status      = M_CP_INT_STATUS.field(Bool(), RO, doc="rx interrupt state register")
       val frame_int_status   = M_CP_INT_STATUS.field(Bool(), RO, doc="frame interrupt state register")
 
-      rx_int_raw.setwhen(rx_done)
-      tx_int_raw.setwhen(tx_done)
-      frame_int_raw.setwhen(frame_int_raw)
+      rx_int_raw.setWhen(io.rx_done)
+      tx_int_raw.setWhen(io.tx_done)
+      frame_int_raw.setWhen(io.frame_end)
 
-      io.interrupt := (rx_int_raw || rx_int_force) && (!rx_int_mask)  ||
-        (tx_int_raw || rx_int_force) && (!rx_int_mask) ||
-        (frame_int_raw || fram_int_force) && (!frame_int_mask)
+      rx_int_status := (rx_int_raw || rx_int_force) && (!rx_int_mask)
+      tx_int_status := (tx_int_raw || rx_int_force) && (!rx_int_mask)
+      frame_int_status := (frame_int_raw || frame_int_force) && (!frame_int_mask)
+
+      io.interrupt := rx_int_status || tx_int_status || frame_int_status
 
    }
 

--- a/source/SpinalHDL/Simulation/examples/dual_clock_fifo.rst
+++ b/source/SpinalHDL/Simulation/examples/dual_clock_fifo.rst
@@ -32,7 +32,7 @@ The FIFO pop thread handles checking the the :abbr:`DUT (Device Under Test)`'s o
            dataType = Bits(32 bits),
            depth = 32,
            pushClock = ClockDomain.external("clkA"),
-           popClock = ClockDomain.external("clkB")
+           popClock = ClockDomain.external("clkB",withReset = false)
          )
        )
 
@@ -46,15 +46,12 @@ The FIFO pop thread handles checking the the :abbr:`DUT (Device Under Test)`'s o
            dut.pushClock.fallingEdge()
            dut.popClock.fallingEdge()
            dut.pushClock.deassertReset()
-           dut.popClock.deassertReset()
            sleep(0)
 
            // Do the resets.
            dut.pushClock.assertReset()
-           dut.popClock.assertReset()
            sleep(10)
            dut.pushClock.deassertReset()
-           dut.popClock.deassertReset()
            sleep(1)
 
            // Forever, randomly toggle one of the clocks.


### PR DESCRIPTION
Fix some minor problems in Libraries and Simulation 
val a = 32.toBigInt        a is 32
There is an error with the same code on the official website

![image](https://user-images.githubusercontent.com/45084662/181228351-8fdc541d-364a-4773-a850-6f2b531a4d95.png)
change to Apb3BusInterface
Interrupt Factory There are  small problems

1. is setWhen  no setwhen
2.is  frame_int_raw no fram_int_force
3. Status No driver 
Because clk_B in StreamFifoCC does not reset, but the default clock will reset, you need to manually add withReset=false  
And the dut. PopClock. DeassertReset () and dut popClock. AssertReset () have to delete 
![image](https://user-images.githubusercontent.com/45084662/181229042-578cf01a-02b3-4eb9-b334-c069dd49b74e.png)
