### PR TITLE
Add Stream simulation driver/monitor docs

### DIFF
--- a/source/SpinalHDL/Libraries/stream.rst
+++ b/source/SpinalHDL/Libraries/stream.rst
@@ -502,3 +502,59 @@ This util take its input stream and routes it to ``outputCount`` stream in a seq
      input = inputStream,
      outputCount = 3
    )
+
+Simulation support
+------------------
+
+For simulation master and slave implementations are available:
+
+.. list-table::
+  :header-rows: 1
+  :widths: 1 5
+  
+  * - Class
+    - Usage
+  * - StreamMonitor
+    - Used for both master and slave sides, calls function with payload if Stream fires.
+  * - StreamDriver
+    - Testbench master side, drives values by calling function to apply value (if available). Function must return if value was available. Supports random delays.
+  * - StreamReadyRandmizer
+    - Randomizes ``ready`` for reception of data, testbench is the slave side.
+  * - ScoreboardInOrder
+    - Often used to compare reference/dut data
+
+.. code-block:: scala
+
+  import spinal.core._
+  import spinal.core.sim._
+  import spinal.lib._
+  import spinal.lib.sim.{StreamMonitor, StreamDriver, StreamReadyRandomizer, ScoreboardInOrder}
+
+  object Example extends App {
+    val dut = SimConfig.withWave.compile(StreamFifo(Bits(8 bit, 2)))
+
+    dut.doSim("simple test") { dut =>
+      SimTimeout(10000)
+      
+      val scoreboard = ScoreboardInOrder[Int]()
+      
+      // drive random data and add pushed data to scoreboard
+      StreamDriver(dut.io.push, dut.clockDomain) { payload =>
+        payload.randomize()
+        true
+      }
+      StreamMonitor(dut.io.push, dut.clockDomain) { payload =>
+        scoreboard.pushRef(payload.toInt)
+      }
+
+      // randmize ready on the output and add popped data to scoreboard
+      StreamReadyRandomizer(dut.io.pop, dut.clockDomain)
+      StreamMonitor(dut.io.pop, dut.clockDomain) { payload =>
+        scoreboard.pushDut(payload.toInt)
+      }
+
+      dut.clockDomain.forkStimulus(10)
+
+      dut.clockDomain.waitActiveEdgeWhere(scoreboard.matches == 100)
+    }
+  }


### PR DESCRIPTION
I know that there is currently no documentation of simulation utilities with their respective SpinalHDL constructs so this is kind of a first - still makes sense to me though, for me this is the most likely location to search for it (apart from RTFS)
