### PR TITLE
fix: last example "Simulation support"

### DIFF
--- a/source/SpinalHDL/Libraries/stream.rst
+++ b/source/SpinalHDL/Libraries/stream.rst
@@ -562,7 +562,7 @@ For simulation master and slave implementations are available:
   import spinal.lib.sim.{StreamMonitor, StreamDriver, StreamReadyRandomizer, ScoreboardInOrder}
 
   object Example extends App {
-    val dut = SimConfig.withWave.compile(StreamFifo(Bits(8 bit, 2)))
+    val dut = SimConfig.withWave.compile(StreamFifo(Bits(8 bits), 2))
 
     dut.doSim("simple test") { dut =>
       SimTimeout(10000)

--- a/source/SpinalHDL/Libraries/stream.rst
+++ b/source/SpinalHDL/Libraries/stream.rst
@@ -569,6 +569,8 @@ For simulation master and slave implementations are available:
       
       val scoreboard = ScoreboardInOrder[Int]()
       
+      dut.io.flush #= false
+      
       // drive random data and add pushed data to scoreboard
       StreamDriver(dut.io.push, dut.clockDomain) { payload =>
         payload.randomize()


### PR DESCRIPTION
It was not building. Now it builds but it still does not pass the test.

The test fails: `Timeout trigger after 10000 units of time`