### PR TITLE
document coverUnreachable and strict options for the switch block

### DIFF
--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -101,7 +101,7 @@ is equivalent to
 Additional options
 ^^^^^^^^^^^^^^^^^^
 
-Sometimes handling all cases can become unwieldy and error prone so SpinalHDL, by default, will handle the uncovered cases with the last ``is`` block.
+Sometimes handling all cases can become unwieldy and error prone so SpinalHDL, by default, handles the uncovered cases with the last ``is`` block.
 To explicitly declare and define a ``default`` block the option ``coverUnreachable`` can be passed to the switch
 
 .. code-block:: scala

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -141,7 +141,7 @@ To relax the strictness of the ``switch`` elaboration the ``strict = false`` can
           foo := 4
           bar := 2
       }
-      is(OP_SLT){
+      is(OP_SLT) {
           foo := 2
           bar := 8
       }

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -101,7 +101,7 @@ is equivalent to
 Additional options
 ^^^^^^^^^^^^^^^^^^
 
-By default, SpinalHDL will generate an "UNREACHABLE DEFAULT STATEMENT" error if a switch/is contains a ``default`` statement while already all the possible logical values of the 'switch' are covered by the 'is' definitions. You can drop this error reporting by specifying `` switch(myValue, coverUnreachable = true){ ... }``.
+By default, SpinalHDL will generate an "UNREACHABLE DEFAULT STATEMENT" error if a ``switch`` contains a ``default`` statement while all the possible logical values of the ``switch`` are already covered by the ``is`` statements. You can drop this error reporting by specifying `` switch(myValue, coverUnreachable = true) { ... }``.
 
 .. code-block:: scala
   
@@ -110,20 +110,22 @@ By default, SpinalHDL will generate an "UNREACHABLE DEFAULT STATEMENT" error if 
       is(1) { ... } 
       is(2) { ... }
       is(3) { ... }
-      default { ... } //This will be ok
+      default { ... } // This will be okay
   }
   
-Note, this check is done on the logical values, not on the physical values. For instance, if you have a SpinalEnum(A,B,C) encoded in a on-hot manner, SpinalHDL will only care about the A,B,C values ("001" "010" "100"). Pyhsical values as "000" "011" "101" "110" "111" will not be taken in account.
+.. note::
+
+   This check is done on the logical values, not on the physical values. For instance, if you have a SpinalEnum(A,B,C) encoded in a on-hot manner, SpinalHDL will only care about the A,B,C values ("001" "010" "100"). Pyhsical values as "000" "011" "101" "110" "111" will not be taken in account.
 
 
-By default, SpinalHDL will generate an "DUPLICATED ELEMENTS IN SWITCH IS(...) STATEMENT" error if a given ``is`` statements provides multiple time the same value. For instance ``is(42,42) { .. }`` 
-You can drop this error reporting by specifying `` switch(myValue, strict = true){ ... }``. SpinalHDL will then take care of removing duplicated values.
+By default, SpinalHDL will generate a "DUPLICATED ELEMENTS IN SWITCH IS(...) STATEMENT" error if a given ``is`` statement provides multiple times the same value. For instance ``is(42,42) { ... }`` 
+You can drop this error reporting by specifying ``switch(myValue, strict = true){ ... }``. SpinalHDL will then take care of removing duplicated values.
 
 .. code-block:: scala
   
   switch(value, strict = false) {
-      is(0)  { ... }
-      is(1,1,1,1,1)  { ... } //This will be ok
+      is(0) { ... }
+      is(1,1,1,1,1) { ... } // This will be okay
       is(2) { ... }
   }
 

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -112,6 +112,8 @@ By default, SpinalHDL will generate an "UNREACHABLE DEFAULT STATEMENT" error if 
       is(3) { ... }
       default { ... } //This will be ok
   }
+  
+Note, this check is done on the logical values, not on the physical values. For instance, if you have a SpinalEnum(A,B,C) encoded in a on-hot manner, SpinalHDL will only care about the A,B,C values ("001" "010" "100"). Pyhsical values as "000" "011" "101" "110" "111" will not be taken in account.
 
 
 By default, SpinalHDL will generate an "DUPLICATED ELEMENTS IN SWITCH IS(...) STATEMENT" error if a given ``is`` statements provides multiple time the same value. For instance ``is(42,42) { .. }`` 

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -137,7 +137,7 @@ To relax the strictness of the ``switch`` elaboration the ``strict = false`` can
   val bar = UInt(8 bits)
   switch(io.instruction, strict = false) {
       // 
-      is(OP_ADD, OP_SUB){
+      is(OP_ADD, OP_SUB) {
           foo := 4
           bar := 2
       }

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -101,8 +101,7 @@ is equivalent to
 Additional options
 ^^^^^^^^^^^^^^^^^^
 
-In some cases when covering all cases of the input encoding still leaves uncovered codes. 
-In the generated HDL these will be handled by default with the last ``is`` block.
+Sometimes handling all cases can become unwieldy and error prone so SpinalHDL, by default, will handle the uncovered cases with the last ``is`` block.
 To explicitly declare and define a ``default`` block the option ``coverUnreachable`` can be passed to the switch
 
 .. code-block:: scala

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -149,7 +149,7 @@ To relax the strictness of the ``switch`` elaboration the ``strict = false`` can
           foo := 2
           bar := 8
       }
-      default{
+      default {
           foo := 0
           bar := 0
       }

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -101,58 +101,28 @@ is equivalent to
 Additional options
 ^^^^^^^^^^^^^^^^^^
 
-Sometimes handling all cases can become unwieldy and error prone so SpinalHDL, by default, handles the uncovered cases with the last ``is`` block.
-To explicitly declare and define a ``default`` block the option ``coverUnreachable`` can be passed to the switch
-
-.. code-block:: scala
-
-  switch(aluop, coverUnreachable = true) {
-    is(ALUOp.add, ALUOp.slt, ALUOp.sltu) {
-        immediate := instruction.immI.signExtend
-    }
-    is(ALUOp.sll, ALUOp.sra) {
-        immediate := instruction.shamt
-    }
-    default{
-        immediate := 0
-    }
-  }
-
-If the used values of ``ALUOp`` are all available elements of the SpinalEnum type, then without the ``coverUnreachable = true`` option SpinalHDL would throw an UNREACHABLE STATEMENT error upon elaboration.
-Without the ``default`` block the encoding for ``ALUOp.sll`` and ``ALUOp.sra`` are the default cases in the generated HDL.
-
-When using defined constants to compare against within a ``switch`` block it can occasionally happen that duplicates within a ``is`` value occur. 
-By default duplicates of ``is`` conditions are not ignored but identified as an error. 
-To relax the strictness of the ``switch`` elaboration the ``strict = false`` can be passed (by default ``strict = true`` thus preventing duplicate ``is`` conditions).
+By default, SpinalHDL will generate an "UNREACHABLE DEFAULT STATEMENT" error if a switch/is contains a ``default`` statement while already all the possible logical values of the 'switch' are covered by the 'is' definitions. You can drop this error reporting by specifying `` switch(myValue, coverUnreachable = true){ ... }``.
 
 .. code-block:: scala
   
-  // OP_ADD and OP_SUB share the same code
-  def OP_ADD = M"000"
-  def OP_SUB = M"000"
-  def OP_SLT = M"001"
-  def OP_JMP = M"010"
-  def OP_BRK = M"101"
-  val foo = UInt(8 bits)
-  val bar = UInt(8 bits)
-  switch(io.instruction, strict = false) {
-      // 
-      is(OP_ADD, OP_SUB) {
-          foo := 4
-          bar := 2
-      }
-      is(OP_SLT) {
-          foo := 2
-          bar := 8
-      }
-      is(OP_JMP, OP_BRK) {
-          foo := 2
-          bar := 8
-      }
-      default {
-          foo := 0
-          bar := 0
-      }
+  switch(my2Bits, coverUnreachable = false) {
+      is(0) { ... }
+      is(1) { ... } 
+      is(2) { ... }
+      is(3) { ... }
+      default { ... } //This will be ok
+  }
+
+
+By default, SpinalHDL will generate an "DUPLICATED ELEMENTS IN SWITCH IS(...) STATEMENT" error if a given ``is`` statements provides multiple time the same value. For instance ``is(42,42) { .. }`` 
+You can drop this error reporting by specifying `` switch(myValue, strict = true){ ... }``. SpinalHDL will then take care of removing duplicated values.
+
+.. code-block:: scala
+  
+  switch(value, strict = false) {
+      is(0)  { ... }
+      is(1,1,1,1,1)  { ... } //This will be ok
+      is(2) { ... }
   }
 
 

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -97,6 +97,66 @@ is equivalent to
     }
   }
 
+
+Additional options
+^^^^^^^^^^^^^^^^^^
+
+In some cases when covering all cases of the input encoding still leaves uncovered codes. 
+In the generated HDL these will be handled by default with the last ``is`` block.
+To explicitly declare and define a ``default`` block the option ``coverUnreachable`` can be passed to the switch
+
+.. code-block:: scala
+
+  switch(aluop, coverUnreachable = true) {
+    is(ALUOp.add, ALUOp.slt, ALUOp.sltu) {
+        immediate := instruction.immI.signExtend
+    }
+    is(ALUOp.sll, ALUOp.sra) {
+        immediate := instruction.shamt
+    }
+    default{
+        immediate := 0
+    }
+  }
+
+If the used values of ``ALUOp`` are all available elements of the SpinalEnum type, then without the ``coverUnreachable = true`` option SpinalHDL would throw an UNREACHABLE STATEMENT error upon elaboration.
+Without the ``default`` block the encoding for ``ALUOp.sll`` and ``ALUOp.sra`` are the default cases in the generated HDL.
+
+When using defined constants to compare against within a ``switch`` block it can occasionally happen that duplicates within a ``is`` value occur. 
+By default duplicates of ``is`` conditions are not ignored but identified as an error. 
+To relax the strictness of the ``switch`` elaboration the ``strict = false`` can be passed (by default ``strict = true`` thus preventing duplicate ``is`` conditions).
+
+.. code-block:: scala
+  
+  // OP_ADD and OP_SUB share the same code
+  def OP_ADD = M"000"
+  def OP_SUB = M"000"
+  def OP_SLT = M"001"
+  def OP_JMP = M"010"
+  def OP_BRK = M"101"
+  val foo = UInt(8 bits)
+  val bar = UInt(8 bits)
+  switch(io.instruction, strict=false){
+      // 
+      is(OP_ADD, OP_SUB){
+          foo := 4
+          bar := 2
+      }
+      is(OP_SLT){
+          foo := 2
+          bar := 8
+      }
+      is(OP_JMP, OP_BRK){
+          foo := 2
+          bar := 8
+      }
+      default{
+          foo := 0
+          bar := 0
+      }
+  }
+
+
 Local declaration
 -----------------
 

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -145,7 +145,7 @@ To relax the strictness of the ``switch`` elaboration the ``strict = false`` can
           foo := 2
           bar := 8
       }
-      is(OP_JMP, OP_BRK){
+      is(OP_JMP, OP_BRK) {
           foo := 2
           bar := 8
       }

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -135,7 +135,7 @@ To relax the strictness of the ``switch`` elaboration the ``strict = false`` can
   def OP_BRK = M"101"
   val foo = UInt(8 bits)
   val bar = UInt(8 bits)
-  switch(io.instruction, strict=false){
+  switch(io.instruction, strict = false) {
       // 
       is(OP_ADD, OP_SUB){
           foo := 4


### PR DESCRIPTION
For #138 discussed in [SpinalHDL/SpinalHDL#946](https://github.com/SpinalHDL/SpinalHDL/issues/946) 

also added documentation for the strict option since its part of the same structure and would belong in the same place.

I am open for slightly less technical/deep descriptions of these parameters as I dont know if it would confuse anyone reading that first time.