### PR TITLE
Add graySequential enum encoding

### DIFF
--- a/source/SpinalHDL/Data types/enum.rst
+++ b/source/SpinalHDL/Data types/enum.rst
@@ -46,15 +46,18 @@ The following enumeration encodings are supported:
    * - Encoding
      - Bit width
      - Description
-   * - native
+   * - ``native``
      - 
      - Use the VHDL enumeration system, this is the default encoding
-   * - binarySequential
-     - log2Up(stateCount)
+   * - ``binarySequential``
+     - ``log2Up(stateCount)``
      - Use Bits to store states in declaration order (value from 0 to n-1)
-   * - binaryOneHot
+   * - ``binaryOneHot``
      - stateCount
      - Use Bits to store state. Each bit corresponds to one state
+   * - ``graySequential``
+     - ``log2Up(stateCount)``
+     - Encode index (numbers as if using ``binarySequential``) as binary gray code.
 
 Custom encodings can be performed in two different ways: static or dynamic.
 

--- a/source/SpinalHDL/Libraries/fsm.rst
+++ b/source/SpinalHDL/Libraries/fsm.rst
@@ -140,6 +140,36 @@ Transitions
 These two functions can be used inside state definitions (see below) or using ``always { yourStatements }``,
 which always applies ``yourStatements``, with a priority over states.
 
+State encoding
+^^^^^^^^^^^^^^
+
+By default the FSM state vector will be encoded using the native encoding of the language/tools the RTL is generated for (Verilog or VHDL).
+This default can be overriden by using the ``setEncoding(...)`` method which either takes a ``SpinalEnumEncoding`` or
+varargs of type ``(State, BigInt)`` for a custom encoding. 
+
+.. code-block:: scala
+   :caption: Using a ``SpinalEnumEncoding``
+   
+   val fsm = new StateMachine {
+     setEncoding(binaryOneHot)
+
+     ...
+   }
+
+.. code-block:: scala
+   :caption: Using a custom encoding
+
+   val fsm = new StateMachine {
+     val stateA = new State with EntryPoint
+     val stateB = new State
+     ...
+     setEncoding((stateA -> 0x23), (stateB -> 0x22))
+   }
+
+.. warning:: When using the ``graySequential`` enum encoding, no check is done to verify that the FSM transitions only produce
+             single-bit changes in the state vector. The encoding is done according to the order of state definitions and the
+             designer must ensure that only valid transitions are done if needed.
+
 States
 ------
 

--- a/source/SpinalHDL/Libraries/fsm.rst
+++ b/source/SpinalHDL/Libraries/fsm.rst
@@ -188,21 +188,29 @@ Each of them provides the following functions to define the logic associated to 
 
    * - Name
      - Description
-   * - | ``state.onEntry {``
-       | ``  yourStatements``
-       | ``}``
+   * - .. code-block:: scala
+     
+          state.onEntry {
+            yourStatements
+          }
      - ``yourStatements`` is applied when the state machine is not in ``state`` and will be in ``state`` the next cycle
-   * - | ``state.onExit {``
-       | ``  yourStatements``
-       | ``}``
+   * - .. code-block:: scala
+         
+          state.onExit {
+            yourStatements
+          }
      - ``yourStatements`` is applied when the state machine is in ``state`` and will be in another state the next cycle
-   * - | ``state.whenIsActive {``
-       | ``  yourStatements``
-       | ``}``
+   * - .. code-block:: scala
+     
+          state.whenIsActive {
+            yourStatements
+          }
      - ``yourStatements`` is applied when the state machine is in ``state``
-   * - | ``state.whenIsNext {``
-       | ``  yourStatements``
-       | ``}``
+   * - .. code-block:: scala
+     
+          state.whenIsNext {
+            yourStatements
+          }
      - ``yourStatements`` is executed when the state machine will be in ``state`` the next cycle (even if it is already in it)
 
 ``state.`` is implicit in a ``new State`` block:


### PR DESCRIPTION
Add encoding added in https://github.com/SpinalHDL/SpinalHDL/pull/967
Also fixes broken syntax highlighting on the FSM page.

For now I did not extract the code examples to our checked build, I'd leave that for a separate commit that does not add any now code to make the review easier.