### PR TITLE
document building SpinalHDL with mill

### DIFF
--- a/source/SpinalHDL/Developers area/mill support.rst
+++ b/source/SpinalHDL/Developers area/mill support.rst
@@ -1,0 +1,47 @@
+Build through Mill
+==================
+
+SpinalHDL itself can be built by Mill build tools, it could compile/test/publishLocal the existing modules.
+Build through mill can be much faster than sbt, which is useful while debugging.
+
+Complie the library
+-------------------
+
+.. code-block:: sh
+
+   mill __.compile
+   sbt compile # equivalent alternatives
+
+Run all test suite
+------------------
+
+.. code-block:: sh
+
+   mill __.test
+   sbt test # equivalent alternatives
+
+Test a specified suite
+----------------------
+
+.. code-block:: sh
+
+   mill tester.test.testOnly spinal.xxxxx.xxxxx
+   sbt "tester/testOnly spinal.xxxxx.xxxxx" # equivalent alternatives
+
+Run a specified App
+-------------------
+
+.. code-block:: sh
+
+   mill tester.runMain spinal.xxxxx.xxxxx
+   sbt "tester/runMain spinal.xxxxx.xxxxx" # equivalent alternatives
+
+Publish locally
+---------------
+
+it can also publish the library to local ivy2 repos as a ``dev`` version.
+
+.. code-block:: sh
+
+   mill __.publishLocal
+   sbt publishLocal # equivalent alternatives

--- a/source/SpinalHDL/Developers area/mill support.rst
+++ b/source/SpinalHDL/Developers area/mill support.rst
@@ -1,8 +1,8 @@
 Build through Mill
 ==================
 
-SpinalHDL itself can be built by Mill build tools, it could compile/test/publishLocal the existing modules.
-Build through mill can be much faster than sbt, which is useful while debugging.
+SpinalHDL itself can be built with Mill. It can compile/test/publishLocal the existing modules.
+Build through mill can be much faster than Sbt, which is useful while debugging.
 
 Complie the library
 -------------------
@@ -12,16 +12,16 @@ Complie the library
    mill __.compile
    sbt compile # equivalent alternatives
 
-Run all test suite
-------------------
+Run all test suites
+-------------------
 
 .. code-block:: sh
 
    mill __.test
    sbt test # equivalent alternatives
 
-Test a specified suite
-----------------------
+Run a specified test suite
+--------------------------
 
 .. code-block:: sh
 
@@ -39,7 +39,7 @@ Run a specified App
 Publish locally
 ---------------
 
-it can also publish the library to local ivy2 repos as a ``dev`` version.
+Mill can also publish the library to the local ivy2 repository as a ``dev`` version.
 
 .. code-block:: sh
 


### PR DESCRIPTION
Content is as title described.

However, this failed in my CI by error "source/SpinalHDL/Data types/bits.rst:265: ERROR: Error parsing content block for the "list-table" directive: uniform two-level bullet list expected, but row 3 does not contain the same number of items as row 1 (2 vs 3)."
@numero-744 can you have a look at it?