### PR TITLE
Add Elitestek to companies using SpinalHDL page

### DIFF
--- a/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
+++ b/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
@@ -19,3 +19,4 @@ Companies
 * QsPin, Belgium
 * DatenLord, China
 * `LeafLabs, Massachusetts USA <https://www.leaflabs.com>`_
+* `Elitestek(FPGA Vendor),China <https://elitestek.com/product/RISC_V/>`

--- a/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
+++ b/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
@@ -19,4 +19,4 @@ Companies
 * QsPin, Belgium
 * DatenLord, China
 * `LeafLabs, Massachusetts USA <https://www.leaflabs.com>`_
-* `Elitestek(FPGA Vendor),China <https://elitestek.com/product/RISC_V/>`
+* `Elitestek(FPGA Vendor), China <https://elitestek.com/product/RISC_V/>`


### PR DESCRIPTION
Elitestek has used the VexRISC-V core in FPGAs and applied in multi applications in worldwide customers.