### PR TITLE
update verilator's version from v4.040 -> v4.218

### DIFF
--- a/source/SpinalHDL/Simulation/install/Verilator.rst
+++ b/source/SpinalHDL/Simulation/install/Verilator.rst
@@ -34,7 +34,7 @@ You will also need a recent version of Verilator installed :
    unset VERILATOR_ROOT  # For bash
    cd verilator
    git pull        # Make sure we're up-to-date
-   git checkout v4.040
+   git checkout v4.218
    autoconf        # Create ./configure script
    ./configure
    make -j$(nproc)


### PR DESCRIPTION
in [tool.sh](https://github.com/SpinalHDL/SpinalHDL/blob/4a21ab4cca95b35fbb12189077e7609e7b40dbb9/tools.sh#L9), the version of verilator is updated to `v4.218`, while the Doc still recommands the `v4.040`, maybe we need to update the Doc