### PR TITLE
Update SpinalHDL version for examples to 1.8.0b

### DIFF
--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / version := "1.0"
 ThisBuild / scalaVersion := "2.12.16"
 ThisBuild / organization := "org.example"
 
-val spinalVersion = "1.7.3"
+val spinalVersion = "1.8.0b"
 val spinalCore = "com.github.spinalhdl" %% "spinalhdl-core" % spinalVersion
 val spinalLib = "com.github.spinalhdl" %% "spinalhdl-lib" % spinalVersion
 val spinalIdslPlugin = compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % spinalVersion)


### PR DESCRIPTION
Simply update so that we can use e.g. `in port Bool()`