### PR TITLE
Fix order of slices from subdivideIn

### DIFF
--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -458,10 +458,10 @@ Misc
    // Subdivide
    val sel = UInt(2 bits)
    val mySIntWord = mySInt_128bits.subdivideIn(32 bits)(sel)
-       // sel = 0 => mySIntWord = mySInt_128bits(127 downto 96)
-       // sel = 1 => mySIntWord = mySInt_128bits( 95 downto 64)
-       // sel = 2 => mySIntWord = mySInt_128bits( 63 downto 32)
-       // sel = 3 => mySIntWord = mySInt_128bits( 31 downto  0)
+       // sel = 3 => mySIntWord = mySInt_128bits(127 downto 96)
+       // sel = 2 => mySIntWord = mySInt_128bits( 95 downto 64)
+       // sel = 1 => mySIntWord = mySInt_128bits( 63 downto 32)
+       // sel = 0 => mySIntWord = mySInt_128bits( 31 downto  0)
 
     // If you want to access in reverse order you can do:
     val myVector   = mySInt_128bits.subdivideIn(32 bits).reverse
@@ -470,7 +470,7 @@ Misc
    // Resize
    myUInt_32bits := U"32'x112233344"
    myUInt_8bits  := myUInt_32bits.resized       // automatic resize (myUInt_8bits = 0x44)
-   myUInt_8bits  := myUInt_32bits.resize(8)     // resize to 8 bits (myUInt_8bits = 0x44)
+   val lowest_8bits = myUInt_32bits.resize(8)  // resize to 8 bits (myUInt_8bits = 0x44)
 
    // Two's complement
    mySInt := myUInt.twoComplement(myBool)


### PR DESCRIPTION
It strikes me as weird that no one noticed this but
```scala
case class TestX() extends Component {
  val i = in Bits(128 bit)
  val o = out Bits(32 bit)
  o := i.subdivideIn(32 bit)(0)
}
object TestXX extends App {
  SpinalVerilog(TestX())
}
```
generates
```
module TestX (
  input      [127:0]  i,
  output     [31:0]   o
);


  assign o = i[31 : 0];

endmodule
```
Which indicates that the ordering was documented incorrectly