### PR TITLE
Global project updates

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,588 @@
+name: "build_and_deploy"
+
+on:
+  workflow_dispatch:
+    inputs:
+      BUILD_SINGLE_DOC:
+        description: 'Build single version ?'
+        required: false
+        type: boolean
+        default: false
+      BUILD_MULTI_DOC:
+        description: 'Build multi version (live) ?'
+        required: false
+        type: boolean
+        default: true
+      FAILON_LINKCHECK:
+        description: 'Enforce make linkcheck (live) ?'
+        required: false
+        type: boolean
+        default: true
+      SKIP_LINKCHECK:
+        description: 'Skip make linkcheck ?'
+        required: false
+        type: boolean
+        default: false
+      DEPLOY_ENV_TEST:
+        description: 'Deploy to test ?'
+        required: false
+        type: boolean
+        default: false
+      DEPLOY_ENV_LIVE:
+        description: 'Deploy to live ?'
+        required: false
+        type: boolean
+        default: false
+  pull_request:
+    env:	# This doesn't error but doesn't work like you might expect, see the steps below
+      BUILD_SINGLE_DOC: true
+      BUILD_MULTI_DOC: false
+      FAILON_LINKCHECK: false
+      SKIP_LINKCHECK: true
+  push:
+    branches:
+      - 'test'
+    env:	# This doesn't error but doesn't work like you might expect, see the steps below
+      BUILD_SINGLE_DOC: true
+      BUILD_MULTI_DOC: true
+      FAILON_LINKCHECK: false
+      SKIP_LINKCHECK: true
+      DEPLOY_ENV_TEST: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    # The purpose of these outputs is to allow the separate 'deploy' job to pickup the same values
+    outputs:
+      DEPLOY_ENV_TEST: ${{ steps.confenv.outputs.DEPLOY_ENV_TEST }}
+      DEPLOY_ENV_LIVE: ${{ steps.confenv.outputs.DEPLOY_ENV_LIVE }}
+      deploy: ${{ steps.github-pages.outputs.deploy }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0   ## all branches all tags
+
+    - name: 'CI-ENV on: workflow_dispatch'
+      if: github.event_name == 'workflow_dispatch'
+      env:
+        inputs_BUILD_SINGLE_DOC: ${{ inputs.BUILD_SINGLE_DOC }}
+        inputs_BUILD_MULTI_DOC:  ${{ inputs.BUILD_MULTI_DOC  }}
+        inputs_SKIP_LINKCHECK:   ${{ inputs.SKIP_LINKCHECK   }}
+        inputs_FAILON_LINKCHECK: ${{ inputs.FAILON_LINKCHECK }}
+        inputs_DEPLOY_ENV_TEST:  ${{ inputs.DEPLOY_ENV_TEST  }}
+        inputs_DEPLOY_ENV_LIVE:  ${{ inputs.DEPLOY_ENV_LIVE  }}
+      run: |
+        # Canonicalize variable values "true" or "false" or default (not set)
+        for ename in BUILD_SINGLE_DOC BUILD_MULTI_DOC SKIP_LINKCHECK FAILON_LINKCHECK DEPLOY_ENV_TEST DEPLOY_ENV_LIVE
+        do
+          iname="inputs_${ename}"
+          value="${!iname}"
+          # inputs context has lower precedence than existing env (which is usually notset)
+          # set ename (env) from iname (inputs) if ename notset and value being set is not blank
+          if [ "${!ename-notset}" = "notset" ] && [ "X${value}" != "X" ]
+          then
+            declare "${ename}=${value}"
+            echo "${ename}=${!ename}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV on: release'
+      if: github.event_name == 'release'
+      run: |
+        # Actions don't support env setup from on: specification so we have to do it inside a step
+        for namevalue in {BUILD_SINGLE_DOC=false,BUILD_MULTI_DOC=true,FAILON_LINKCHECK=true,DEPLOY_ENV_LIVE=true}
+        do
+          name="${namevalue%=*}"
+          value="${namevalue#*=}"
+          if [ "${!name-notset}" = "notset" ]
+          then
+            declare "${name}=${value}"
+            echo "${name}=${!name}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV on: schedule'
+      if: github.event_name == 'schedule'
+      run: |
+        # Actions don't support env setup from on: specification so we have to do it inside a step
+        for namevalue in {BUILD_SINGLE_DOC=false,BUILD_MULTI_DOC=true,FAILON_LINKCHECK=false,DEPLOY_ENV_LIVE=true}
+        do
+          name="${namevalue%=*}"
+          value="${namevalue#*=}"
+          if [ "${!name-notset}" = "notset" ]
+          then
+            declare "${name}=${value}"
+            echo "${name}=${!name}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV on: push'	# if you use a branch called 'test' see on: push
+      if: github.event_name == 'push'
+      run: |
+        # Actions don't support env setup from on: specification so we have to do it inside a step
+        for namevalue in {BUILD_SINGLE_DOC=true,BUILD_MULTI_DOC=true,SKIP_LINKCHECK=true,DEPLOY_ENV_TEST=true}
+        do
+          name="${namevalue%=*}"
+          value="${namevalue#*=}"
+          if [ "${!name-notset}" = "notset" ]
+          then
+            declare "${name}=${value}"
+            echo "${name}=${!name}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV on: pull_request'
+      if: github.event_name == 'pull_request'
+      run: |
+        # Actions don't support env setup from on: specification so we have to do it inside a step
+        for namevalue in {BUILD_SINGLE_DOC=true,SKIP_LINKCHECK=true}
+        do
+          name="${namevalue%=*}"
+          value="${namevalue#*=}"
+          if [ "${!name-notset}" = "notset" ]
+          then
+            declare "${name}=${value}"
+            echo "${name}=${!name}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV Canonicalize'
+      run: |
+        # Canonicalize variable values "true" or "false" or default (not set)
+        for ename in BUILD_SINGLE_DOC BUILD_MULTI_DOC SKIP_LINKCHECK FAILON_LINKCHECK DEPLOY_ENV_TEST DEPLOY_ENV_LIVE
+        do
+          if [ "${!ename+set}" = "set" ]
+          then
+            # The ,, is bash for lowercase the value
+            if [ "${!ename,,}" != "true" ] && [ "${!ename,,}" != "false" ]
+            then
+              echo "ENV ${ename} invalid value: '${!ename}'" 1>&2
+              exit 1
+            fi
+            echo "${ename}=${!ename}" >> $GITHUB_ENV
+          fi
+        done
+
+        cat $GITHUB_ENV
+
+    - name: 'CI-ENV Validate'
+      run: |
+        # Only one DEPLOY mode is allowed, if any
+        if [ "$DEPLOY_ENV_TEST" = "true" ] && [ "$DEPLOY_ENV_LIVE" = "true" ]
+        then
+          echo "ENV invalid params DEPLOY_ENV_TEST=$DEPLOY_ENV_TEST and DEPLOY_ENV_LIVE=$DEPLOY_ENV_LIVE" 1>&2
+          exit 1
+        fi
+
+        if [ "$DEPLOY_ENV_LIVE" = "true" ]
+        then
+          # When deploying LIVE only one BUILD mode is allowed (this is to prevent accidents)
+          # disallow deployment of multiple versions
+          if [ "$BUILD_SINGLE_DOC" = "true" ] && [ "$BUILD_MULTI_DOC" = "true" ]
+          then
+            echo "ENV invalid params BUILD_SINGLE_DOC=$BUILD_SINGLE_DOC and BUILD_MULTI_DOC=$BUILD_MULTI_DOC" 1>&2
+            exit 1
+          fi
+
+          # Maybe this should be the rule for the policy at this time (this is to prevent accidents)
+          # force only BUILD_MULTI_DOC
+          if [ "$BUILD_MULTI_DOC" != "true" ]
+          then
+            echo "ENV invalid params BUILD_MULTI_DOC=$BUILD_MULTI_DOC" 1>&2
+            exit 1
+          fi
+        fi
+
+        echo "Validation: SUCCESS"
+        exit 0
+
+    - name: Configure ENV
+      id: confenv
+      run: |
+        ## transform: mayexist/username/reponame => reponame
+        export GITHUB_REPOSITORY_NAME=$(echo -n "${GITHUB_REPOSITORY}" | sed -e 's#^.*/\([^/]*\)$#\1#')
+        echo "GITHUB_REPOSITORY_NAME=${GITHUB_REPOSITORY_NAME}" >> $GITHUB_ENV
+        export sphinx_extra_version="latest"
+        echo "sphinx_extra_version=${sphinx_extra_version}" >> $GITHUB_ENV
+
+        # Needs trailing slash on these, as final value needs trailing slash
+        # Default is assume multi for production
+        _baseurl_prefix="${sphinx_extra_version}/"
+        if [ "$DEPLOY_ENV_TEST" = "true" ] && [ "$BUILD_MULTI_DOC" = "true" ] && [ "$BUILD_SINGLE_DOC" = "true" ]
+        then
+          # TEST: Prioritize multi when building both
+          _baseurl_prefix="docs_multi/html/${sphinx_extra_version}/"
+        elif [ "$DEPLOY_ENV_TEST" = "true" ] && [ "$BUILD_MULTI_DOC" = "true" ]
+        then
+          # TEST: Looks same as default
+          _baseurl_prefix="${sphinx_extra_version}/"
+        elif [ "$DEPLOY_ENV_TEST" = "true" ] && [ "$BUILD_SINGLE_DOC" = "true" ]
+        then
+          # TEST: This is moved toplevel now (no trailing slash as there is one already when this is empty)
+          #_baseurl_prefix="docs_single/html/${sphinx_extra_version}"
+          _baseurl_prefix=""
+        fi
+        echo "sphinx_html_baseurl=https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY_NAME}/${_baseurl_prefix}" >> $GITHUB_ENV
+
+        echo "sphinx_github_url=https://github.com/${GITHUB_REPOSITORY}" >> $GITHUB_ENV
+
+        # Latest version selection
+        echo "### git show-ref:"
+        git show-ref
+
+        echo "### git for-each-ref:"
+        git for-each-ref --format "%(refname)"
+
+        set +e
+        sphinx_latest_version=$(git for-each-ref --format "%(refname)" | sed 's/^refs\///g' | grep "tags/" | sed -e 's/^tags\///' | sort -g | tail -n1)
+        set -e
+        echo "sphinx_latest_version=${sphinx_latest_version}" >> $GITHUB_ENV
+        if [ "$DEPLOY_ENV_LIVE" != "true" ]
+        then
+          echo "sphinx_html_context_head_meta_robots=noindex,nofollow" >> $GITHUB_ENV
+        fi
+
+        # See if a tags/latest exists
+        if git show-ref -q latest
+        then
+          echo "$(git show-ref ${sphinx_extra_version})  ## ALREADY EXISTS, KEEPING"
+        else
+          gitref=$(git show-ref ${sphinx_latest_version} | cut -d ' ' -f1)
+          git tag "${sphinx_extra_version}" "${gitref}"
+          echo "$(git show-ref ${sphinx_extra_version})  ## CREATED LOCAL ALIAS TO ${sphinx_latest_version}"
+        fi
+
+        # Now we are all configured lets make these settings global
+        for varname in DEPLOY_ENV_TEST DEPLOY_ENV_LIVE
+        do
+          echo "$varname=${!varname}" >> $GITHUB_OUTPUT
+        done
+
+        echo "### $GITHUB_OUTPUT:"
+        cat $GITHUB_OUTPUT
+
+        echo "### $GITHUB_ENV:"
+        cat $GITHUB_ENV
+
+    - name: Setup python 3.9
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        # FIXME use the same docker container, that already has all the trimmings
+        # https://hub.docker.com/r/sphinxdoc/sphinx-latexpdf/tags 5.3.0
+        # Hmm... it does not look like the docker is being updated anymore, stuck at version 5.3.0
+        # this is the version we use today but tomorrow it looks like we are going to have to
+        #  manually install like this anyway.
+        export DEBIAN_FRONTEND=noninteractive
+        sudo apt-get update -y || true
+
+        # Dep list taken from docker image
+        sudo apt-get install --no-install-recommends -y       graphviz       imagemagick       make             latexmk \
+              lmodern       fonts-freefont-otf       texlive-latex-recommended       texlive-latex-extra \
+              texlive-fonts-recommended       texlive-fonts-extra       texlive-lang-cjk \
+              texlive-lang-chinese       texlive-lang-japanese       texlive-luatex       texlive-xetex \
+              xindy       tex-gyre
+        sudo apt-get install -y git	# github-action image already has this
+        #apt-get autoremove  && apt-get clean  && rm -rf /var/lib/apt/lists/* # buildkit
+
+        python3 -m pip install --no-cache-dir -U pip # buildkit
+        python3 -m pip install --no-cache-dir Pillow # buildkit (removed Sphinx, this comes from requirements.txt)
+
+        source bin/setup_env.sh
+        echo "sphinx_latest_version=${sphinx_latest_version}" >> $GITHUB_ENV
+
+        pip install -r requirements.txt
+
+    - uses: ammaraskar/sphinx-problem-matcher@master
+
+    - name: make linkcheck - check links
+      if: ${{ env.SKIP_LINKCHECK != 'true' }}
+      run: |
+        source bin/setup_env.sh
+
+        set +e
+        # This can fail if 3rd party website is down (that maybe one of the points it is checking here)
+        make linkcheck >linkcheck.log 2>&1
+        retval=$?
+        set -e
+        cat linkcheck.log
+
+        if [ $retval -ne 0 ]
+        then
+          # GHA must have slow blocking stdout stream but large buffer
+          # This sleeps ensures the 'cat' above flushed the stream before we might writing to stderr here
+          sleep 3
+
+          # Repeat to STDERR to attract attention
+          echo "### ERROR $retval :" 1>&2
+          egrep "\s(broken)\s" linkcheck.log 1>&2 || true
+
+          if [ "$FAILON_LINKCHECK" = "true" ]
+          then
+            echo "ENV param FAILON_LINKCHECK=$FAILON_LINKCHECK so CI build halted due to: make linkcheck (exit-status=$retval)" 1>&2
+            exit $retval
+          fi
+        fi
+        # Force success if we get here
+        exit 0
+
+    - name: make html - single doc builder
+      if: ${{ env.BUILD_SINGLE_DOC == 'true' }}
+      run: |
+        source bin/setup_env.sh
+
+        rm -f /tmp/convert-wrapper.log
+
+        make html
+        rv=$?
+
+        # Report convert-wrapper failures for CI visibility
+        if grep -q "^FAIL" /tmp/convert-wrapper.log 2>/dev/null
+        then
+          echo "### /tmp/convert-wrapper.log:"
+          grep "^FAIL" /tmp/convert-wrapper.log
+          #rv=1 #this would force this into a step failure
+        fi
+
+        exit $rv
+
+    - name: "move dist/gh-pages/docs_single"
+      if: ${{ env.BUILD_SINGLE_DOC == 'true' }}
+      run: |
+        test -d dist/gh-pages || mkdir -p dist/gh-pages
+        mv -f docs/ dist/gh-pages/docs_single
+
+        if [ "$BUILD_MULTI_DOC" != "true" ]
+        then
+          # only building SINGLE so make it toplevel
+          mv -f dist/gh-pages/docs_single/* dist/gh-pages/
+          find  dist/gh-pages/docs_single -exec ls -lad {} \;
+          rmdir dist/gh-pages/docs_single # ensures dir empty
+          # this exposes doctree/** linkcheck/** (that seems ok)
+          mv -f dist/gh-pages/html/* dist/gh-pages/
+        fi
+
+    - name: sphinx-multiversion - multidoc builder
+      if: ${{ env.BUILD_MULTI_DOC == 'true' }}
+      run: |
+        source bin/setup_env.sh
+
+        test -d dist/gh-pages || mkdir -p dist/gh-pages
+        sphinx-multiversion -D "smv_latest_version=$sphinx_latest_version" --dump-metadata source docs/html > dist/gh-pages/sphinx_metadata.json
+        cat dist/gh-pages/sphinx_metadata.json
+
+        rm -f /tmp/convert-wrapper.log
+
+        # Make the docs
+        sphinx-multiversion -D "smv_latest_version=$sphinx_latest_version" source docs/html
+        rv=$?
+
+        # Report convert-wrapper failures for CI visibility
+        if grep -q "^FAIL" /tmp/convert-wrapper.log 2>/dev/null
+        then
+          echo "### /tmp/convert-wrapper.log:"
+          grep "^FAIL" /tmp/convert-wrapper.log
+          #rv=1 #this would force this into a step failure
+        fi
+
+        exit $rv
+
+    - name: "move dist/gh-pages/docs_multi"
+      if: ${{ env.BUILD_MULTI_DOC == 'true' }}
+      run: |
+        test -d dist/gh-pages || mkdir -p dist/gh-pages
+        mv -f docs/ dist/gh-pages/docs_multi
+
+        if [ "$BUILD_SINGLE_DOC" != "true" ]
+        then
+          # only building MULTI so make it toplevel
+          mv -f dist/gh-pages/docs_multi/* dist/gh-pages/
+          find  dist/gh-pages/docs_multi -exec ls -lad {} \;
+          rmdir dist/gh-pages/docs_multi # ensures dir empty
+          # this exposes doctree/** linkcheck/** (that seems ok)
+          mv -f dist/gh-pages/html/* dist/gh-pages/
+        fi
+
+    - name: "Prepare artifact"
+      run: |
+        set +e
+        # Provide a view of deployment structure to help with any diagnostic
+        for f in "dist/gh-pages/${sphinx_extra_version}/index.html" \
+                 "dist/gh-pages/docs_multi/html/${sphinx_extra_version}/index.html" \
+                 "dist/gh-pages/docs_multi/html/${sphinx_latest_version}/index.html" \
+                 "dist/gh-pages/docs_single/html/index.html" \
+                 "dist/gh-pages/" \
+                 "dist/gh-pages/docs_single/" \
+                 "dist/gh-pages/docs_single/html" \
+                 "dist/gh-pages/docs_multi/" \
+                 "dist/gh-pages/docs_multi/html"
+        do
+          if [ -d "$f" ]
+          then
+            echo "### $f (dir) :"
+            ls -la "$f" || true
+          else
+            echo "### $f (file) :"
+            ls -lad "$f" || true
+          fi
+        done
+        set -e
+
+        if [ -f "dist/gh-pages/${sphinx_extra_version}/index.html" ]
+        then
+          redirect_url="./${sphinx_extra_version}/index.html"
+        elif [ -f "dist/gh-pages/docs_multi/html/${sphinx_extra_version}/index.html" ]
+        then
+          redirect_url="./docs_multi/html/${sphinx_extra_version}/index.html"
+        elif [ -f "dist/gh-pages/docs_multi/html/${sphinx_latest_version}/index.html" ]
+        then
+          redirect_url="./docs_multi/html/${sphinx_latest_version}/index.html"
+        elif [ -f "dist/gh-pages/docs_single/html/index.html" ]
+        then
+          redirect_url="./docs_single/html/index.html"
+        else
+          redirect_url="./${sphinx_extra_version}/index.html"
+        fi
+
+        if [ "X${sphinx_html_context_head_meta_robots}" != "X" ]	# this is already configure in env
+        then
+          meta_robots="<meta http-equiv=\"robots\" content=\"${sphinx_html_context_head_meta_robots}\">"
+          echo "sphinx_html_context_head_meta_robots=$sphinx_html_context_head_meta_robots"
+        fi
+
+        if [ "$DEPLOY_ENV_TEST" = "true" ] && [ ! -f "dist/gh-pages/${sphinx_extra_version}/index.html" ]
+        then
+          # This is added because the page latest/index.html is considered the canonical top level page
+          # But when we deploy multiple to test it is one level down:
+          # Redirect: latest/index.html => docs_multi/latest/index.html
+
+          echo "### dist/gh-pages/${sphinx_extra_version}/index.html: "
+          echo "redirect_url=$redirect_url"
+          test -d "dist/gh-pages/${sphinx_extra_version}" || mkdir -p "dist/gh-pages/${sphinx_extra_version}"
+          sudo tee "dist/gh-pages/${sphinx_extra_version}/index.html" << EOF
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <title>${sphinx_extra_version} :: Redirecting to ${sphinx_extra_version}</title>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=${redirect_url}">
+              ${meta_robots}
+              <link rel="canonical" href="${sphinx_html_baseurl}index.html">
+            </head>
+          </html>
+        EOF
+          # This EOF is indented left one to ensure no leading space exists in shell code
+        fi
+
+        # Never overwrite index.html if it already exists by this stage (because we moved files to toplevel)
+        if [ ! -f "dist/gh-pages/index.html" ]
+        then
+          echo "### dist/gh-pages/index.html: "
+          echo "redirect_url=$redirect_url"
+          test -d "dist/gh-pages" || mkdir -p "dist/gh-pages"
+          sudo tee dist/gh-pages/index.html << EOF
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <title>${GITHUB_REPOSITORY_NAME} :: Redirecting to ${sphinx_extra_version}</title>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=${redirect_url}">
+              ${meta_robots}
+              <link rel="canonical" href="${sphinx_html_baseurl}index.html">
+            </head>
+          </html>
+        EOF
+          # This EOF is indented left one to ensure no leading space exists in shell code
+        fi
+
+        echo "### dist/gh-pages.tar.gz :"
+        echo "DU: $(du -s dist/gh-pages)"
+        echo "DIRS: $(find dist/gh-pages -type d | wc -l)"
+        echo "FILES: $(find dist/gh-pages -type f | wc -l)"
+        echo ""
+        tar -zcf dist/gh-pages.tar.gz -C dist/gh-pages .
+        ls -lad dist/gh-pages.tar.gz
+        sha1sum dist/gh-pages.tar.gz
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: sphinx-docs
+        path: dist/gh-pages.tar.gz
+
+    - name: Upload github-pages
+      if: ${{ env.DEPLOY_ENV_TEST == 'true' || env.DEPLOY_ENV_LIVE == 'true' }}
+      uses: actions/upload-pages-artifact@main
+      with:
+        name: github-pages
+        path: dist/gh-pages
+        retention-days: 90
+
+    - id: github-pages
+      name: Upload github-pages - set outputs
+      if: ${{ env.DEPLOY_ENV_TEST == 'true' || env.DEPLOY_ENV_LIVE == 'true' }}
+      run: |
+        # This really should be built into the upload-artifact actions with just a one-line option
+        if [ "$DEPLOY_ENV_LIVE" = "true" ]
+        then
+          echo "deploy=live" >> $GITHUB_OUTPUT
+        fi
+        if [ "$DEPLOY_ENV_TEST" = "true" ]
+        then
+          echo "deploy=test" >> $GITHUB_OUTPUT
+        fi
+
+        cat $GITHUB_OUTPUT
+
+  deploy:
+    needs: build
+
+    if: needs.build.outputs.DEPLOY_ENV_TEST == 'true' || needs.build.outputs.DEPLOY_ENV_LIVE == 'true'
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    env:
+      DEPLOY_ENV_TEST: ${{ needs.build.outputs.DEPLOY_ENV_TEST }}
+      DEPLOY_ENV_LIVE: ${{ needs.build.outputs.DEPLOY_ENV_LIVE }}
+      DEPLOY: ${{ needs.build.outputs.deploy }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        if: ${{ env.DEPLOY_ENV_TEST == 'true' || env.DEPLOY_ENV_LIVE == 'true' }}
+        uses: actions/deploy-pages@v2
+
+      - name: Summary
+        run: |
+          if [ "$DEPLOY_ENV_TEST" = "true" ]
+          then
+            echo ":white_check_mark: $DEPLOY DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+          elif [ "$DEPLOY_ENV_LIVE" = "true" ]
+          then
+            echo ":ballot_box_with_check: $DEPLOY DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+          else
+            echo ":large_orange_diamond: skip DEPLOYMENT" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/push-doc.yml
+++ b/.github/workflows/push-doc.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
+    env:
+      sphinx_html_baseurl: 'https://spinalhdl.github.io/SpinalDoc-RTD/master/'
+      sphinx_github_url: 'https://github.com/SpinalHDL/SpinalDoc-RTD'
+      sphinx_extra_version: 'master'
     steps:
     - uses: actions/checkout@v3
       with:
@@ -26,9 +30,9 @@ jobs:
         tags: spinaldoc-pdf
         file: pdf.Dockerfile
     - name: Check links
-      run: docker run --rm -v $PWD:/docs spinaldoc-pdf make linkcheck
+      run: docker run --rm -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf make linkcheck
     - name: Build multiversioned doc
-      run: docker run --rm -v $PWD:/docs spinaldoc-pdf sphinx-multiversion source docs/html
+      run: docker run --rm -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf sphinx-multiversion source docs/html
     - name: Add .nojekill
       run: sudo touch docs/html/.nojekyll
     - name: Add redirection to master
@@ -37,10 +41,10 @@ jobs:
         <!DOCTYPE html>
         <html>
           <head>
-            <title>Redirecting to master branch</title>
+            <title>Redirecting to ${sphinx_extra_version}</title>
             <meta charset="utf-8">
-            <meta http-equiv="refresh" content="0; url=./master/index.html">
-            <link rel="canonical" href="https://spinalhdl.github.io/SpinalDoc-RTD/master/index.html">
+            <meta http-equiv="refresh" content="0; url=./${sphinx_extra_version}/index.html">
+            <link rel="canonical" href="${sphinx_html_baseurl}index.html">
           </head>
         </html>
         EOF

--- a/.github/workflows/push-doc.yml
+++ b/.github/workflows/push-doc.yml
@@ -35,9 +35,9 @@ jobs:
         tags: spinaldoc-pdf
         file: pdf.Dockerfile
     - name: Check links
-      run: docker run --rm -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf make linkcheck
+      run: docker run --rm -u $(id -u $USER):$(id -g $USER) -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf make linkcheck
     - name: Build multiversioned doc
-      run: docker run --rm -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf sphinx-multiversion source docs/html
+      run: docker run --rm -u $(id -u $USER):$(id -g $USER) -v $PWD:/docs -e sphinx_html_baseurl -e sphinx_github_url spinaldoc-pdf sphinx-multiversion source docs/html
     - name: Add .nojekill
       run: sudo touch docs/html/.nojekyll
     - name: Add redirection to master

--- a/.github/workflows/push-doc.yml
+++ b/.github/workflows/push-doc.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - master
       - dev
+  schedule:
+    # * is a special character in YAML
+    # setup monthly background build
+    - cron: '45 4 20 * *'
+    # gh-pages have a lifetime ?  90 days ? so we do this once a month to refresh
 
 jobs:
   docs:

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -20,6 +20,10 @@ jobs:
         pip install -r requirements.txt
     - uses: ammaraskar/sphinx-problem-matcher@master
     - name: "check links"
-      run: make linkcheck
+      run: |
+        source bin/setup_env.sh
+        make linkcheck
     - name: "Test doc building"
-      run: make html
+      run: |
+        source bin/setup_env.sh
+        make html

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docs/*
 *.iml
 .venv
 *.bin
+.cache/
+.venv*/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,8 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apb/lists/*
 
+# source /docs/bin/setup_env.sh
+ENV PATH="$PATH:/docs/bin"
+
 ADD requirements.txt /docs
 RUN pip3 install -r requirements.txt

--- a/bin/convert-wrapper
+++ b/bin/convert-wrapper
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+#	Sphinx uses extension: sphinx.ext.imgconverter
+#
+#	This calls out to ImageMagicK convert.
+#
+#	The older docs tags we build have links to 3rd party websites (travis-ci) for SVG badges.
+#	This returns HTTP/404 but the HTML response is kept and processed as if it returned HTTP/200. (bug in spinix?)
+#	When 'convert' tries to convert foobar.svg (which is a .html format file error page) it has a parse error.
+#	This terminates the document building process completely.
+#
+#	This script is a wrapper for convert, if it fails it logs and provides an empty file instead.
+#
+#
+echo $0 $* >> /tmp/convert-wrapper.log
+
+convert "$@"
+rv=$?
+
+if [ $rv -ne 0 ]
+then
+	echo FAIL $rv $0 $* >> /tmp/convert-wrapper.log
+
+	touch "$2"
+
+	rv=0
+fi
+
+exit $rv

--- a/bin/setup_env.sh
+++ b/bin/setup_env.sh
@@ -1,0 +1,35 @@
+#
+# Use: source bin/setup_env.sh
+#
+unset _addPATH
+for i in "$0" "$PWD/$BASH_SOURCE" "$PWD/$_"
+do
+	basedir=$(dirname "$i")
+	if [ -f "${basedir}/convert-wrapper" ]
+	then
+		_addPATH="${basedir}"
+		break
+	elif [ -f "${basedir}/bin/convert-wrapper" ]
+	then
+		_addPATH="${basedir}/bin"
+		break
+	fi
+done
+
+if [ "X${_addPATH}" != "X" ]
+then
+	echo "Adding ${_addPATH} to \$PATH"
+	export PATH="${_addPATH}:$PATH"
+fi
+
+if [ "X$sphinx_latest_version" = "X" ]
+then
+	# Pick the version considered to be the latest.
+	echo "### git:"
+	git for-each-ref --format "%(refname)" | sed 's/^refs\///g' | grep "tags/" | sed -e 's/^tags\///' | sort -g | tail -n1
+	export sphinx_latest_version=$(git for-each-ref --format "%(refname)" | sed 's/^refs\///g' | grep "tags/" | sed -e 's/^tags\///' | sort -g | tail -n1)
+	#echo sphinx_latest_version=$sphinx_latest_version
+fi
+
+echo "### ENV:"
+declare -p | egrep "x sphinx_" | sed -e 's#declare -x \+##'

--- a/pdf.Dockerfile
+++ b/pdf.Dockerfile
@@ -17,5 +17,8 @@ RUN git config --global safe.directory '*'
 
 RUN npm i wavedrom-cli -g
 
+# source /docs/bin/setup_env.sh
+ENV PATH="$PATH:/docs/bin"
+
 ADD requirements.txt /docs
 RUN pip3 install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==5.3.0
-sphinx-rtd-theme==0.5.2
+sphinx-rtd-theme==1.2.1
 sphinxcontrib-wavedrom==3.0.4
 sphinx-multiversion @ git+https://github.com/samuel-emrys/sphinx-multiversion.git@cd723351f687c98d32834226ae7b3ec9e63bcba5

--- a/source/_static/dialog.js
+++ b/source/_static/dialog.js
@@ -1,0 +1,109 @@
+// dialog
+var versionWarningDialog = (function () {
+  const SELECTOR_DIALOG = 'DIALOG#doc-dialog-version'
+  const SELECTOR_BUTTON = 'DIALOG#doc-dialog-version BUTTON.doc-dialog-dismiss'
+  const KEY = 'spinalhdlrtd_dialog_dismiss'
+
+  const dialog = function() {
+    return document.querySelector(SELECTOR_DIALOG)
+  }
+  const button = function() {
+    return document.querySelector(SELECTOR_BUTTON)
+  }
+
+  const close = function() {
+    const dialogEle = dialog()
+    if(dialogEle) {
+      dialogEle.close()
+      dialogEle.classList.add('collapse')	// This should not be needed
+    }
+    return dialogEle
+  }
+
+  const show = function() {
+    const dialogEle = dialog()
+    if(dialogEle) {
+      dialogEle.show()
+      dialogEle.classList.remove('collapse')
+    }
+    return dialogEle
+  }
+
+  const onReady = function() {
+    const dialogEle = dialog()
+    const dialogButton = button()
+
+    if(dialogButton) {
+      $(dialogButton).click(function($evt) {
+        $evt.preventDefault()
+
+        close()
+
+        if(window.localStorage) {
+          localStorage.setItem(KEY, new Date().getTime())
+        }
+      })
+    }
+
+    if(dialogEle) {
+        var dialogShow = false
+
+        var defaultState = $(dialogEle).data('default-state')
+        //console.log('defaultState=', defaultState)
+        if(defaultState === 'show')
+           dialogShow = true
+
+        // Check page data
+        if(window.localStorage) {
+           let ts = localStorage.getItem(KEY)
+           try {
+             ts = parseInt(ts)
+           } catch(e) {
+             ts = undefined
+           }
+           if(ts) {
+             let now = new Date().getTime()
+             if(ts && now < ts + (86400*1000)) {
+               //console.log('dialog-dismiss=close as localStorage', ts, ts + (86400*1000), now)
+               dialogShow = false
+             } else {
+               //console.log('dialog-dismiss=default as localStorage', ts, ts + (86400*1000), now)
+               // default
+             }
+           }
+        }
+
+        // Check URL
+        const loc = window.location.href
+        if(loc.includes('dialog=show')) {
+          //console.log('dialog=show in window.location.href')
+          dialogShow = true
+        } else if(loc.includes('dialog=close')) {
+          //console.log('dialog=close in window.location.href')
+          dialogShow = false
+        }
+
+        //console.log('dialogShow=', dialogShow)
+        if(dialogShow)
+            show() // Opens a non-modal dialog
+        else
+            close()
+
+        dialogEle.classList.remove('hide-once')
+        dialogEle.classList.remove('collapse-once')
+    }
+  }
+
+  return {
+    onReady: onReady,
+    dialog: dialog,
+    button: button,
+    close: close,
+    show: show
+  }
+
+})()
+
+$(document).ready(function() {
+  versionWarningDialog.onReady()
+})

--- a/source/_static/gh-fork-ribbon.css
+++ b/source/_static/gh-fork-ribbon.css
@@ -1,0 +1,124 @@
+/*!
+ * "Fork me on GitHub" CSS ribbon v0.2.3 | MIT License
+ * https://github.com/simonwhitaker/github-fork-ribbon-css
+*/
+
+.github-fork-ribbon {
+  width: 12.1em;
+  height: 12.1em;
+  position: absolute;
+  overflow: hidden;
+  top: 0;
+  right: 0;
+  z-index: 9999;
+  pointer-events: none;
+  font-size: 13px;
+  text-decoration: none;
+  text-indent: -999999px;
+}
+
+.github-fork-ribbon.fixed {
+  position: fixed;
+}
+
+.github-fork-ribbon:hover, .github-fork-ribbon:active {
+  background-color: rgba(0, 0, 0, 0.0);
+}
+
+.github-fork-ribbon:before, .github-fork-ribbon:after {
+  /* The right and left classes determine the side we attach our banner to */
+  position: absolute;
+  display: block;
+  width: 15.38em;
+  height: 1.54em;
+
+  top: 3.23em;
+  right: -3.23em;
+
+  -webkit-box-sizing: content-box;
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+
+  -webkit-transform: rotate(45deg);
+  -moz-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  -o-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+
+.github-fork-ribbon:before {
+  content: "";
+
+  /* Add a bit of padding to give some substance outside the "stitching" */
+  padding: .38em 0;
+
+  /* Set the base colour */
+  background-color: #a00;
+
+  /* Set a gradient: transparent black at the top to almost-transparent black at the bottom */
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0)), to(rgba(0, 0, 0, 0.15)));
+  background-image: -webkit-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -moz-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -ms-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: -o-linear-gradient(top, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+  background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.15));
+
+  /* Add a drop shadow */
+  -webkit-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  -moz-box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+  box-shadow: 0 .15em .23em 0 rgba(0, 0, 0, 0.5);
+
+  pointer-events: auto;
+}
+
+.github-fork-ribbon:after {
+  /* Set the text from the data-ribbon attribute */
+  content: attr(data-ribbon);
+
+  /* Set the text properties */
+  color: #fff;
+  font: 700 1em "Helvetica Neue", Helvetica, Arial, sans-serif;
+  line-height: 1.54em;
+  text-decoration: none;
+  text-shadow: 0 -.08em rgba(0, 0, 0, 0.5);
+  text-align: center;
+  text-indent: 0;
+
+  /* Set the layout properties */
+  padding: .15em 0;
+  margin: .15em 0;
+
+  /* Add "stitching" effect */
+  border-width: .08em 0;
+  border-style: dotted;
+  border-color: #fff;
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.github-fork-ribbon.left-top, .github-fork-ribbon.left-bottom {
+  right: auto;
+  left: 0;
+}
+
+.github-fork-ribbon.left-bottom, .github-fork-ribbon.right-bottom {
+  top: auto;
+  bottom: 0;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after {
+  right: auto;
+  left: -3.23em;
+}
+
+.github-fork-ribbon.left-bottom:before, .github-fork-ribbon.left-bottom:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  top: auto;
+  bottom: 3.23em;
+}
+
+.github-fork-ribbon.left-top:before, .github-fork-ribbon.left-top:after, .github-fork-ribbon.right-bottom:before, .github-fork-ribbon.right-bottom:after {
+  -webkit-transform: rotate(-45deg);
+  -moz-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  -o-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+}

--- a/source/_static/gh-fork-ribbon.txt
+++ b/source/_static/gh-fork-ribbon.txt
@@ -1,0 +1,27 @@
+
+sha1:9a5785913fdaa8bcd6722dec0d4b4c03022e3ea9  gh-fork-ribbon.css
+
+wget https://raw.githubusercontent.com/simonwhitaker/github-fork-ribbon-css/0.2.3/gh-fork-ribbon.css
+
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Simon Whitaker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/source/_static/github-corner-right.css
+++ b/source/_static/github-corner-right.css
@@ -1,0 +1,16 @@
+.github-corner:hover .octo-arm {
+ animation:octocat-wave 560ms ease-in-out
+}
+@keyframes octocat-wave {
+ 0%,100% { transform:rotate(0) }
+ 20%,60% { transform:rotate(-25deg) }
+ 40%,80% { transform:rotate(10deg) }
+}
+@media (max-width:500px) {
+ .github-corner:hover .octo-arm {
+   animation:none
+ }
+ .github-corner .octo-arm {
+   animation:octocat-wave 560ms ease-in-out
+ }
+}

--- a/source/_static/github-corner-right.svg
+++ b/source/_static/github-corner-right.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"> -->
+<?xml-stylesheet href="github-corner-right.css" type="text/css"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 250 250" class="github-corner" style="position: absolute; top: 0; right: 0" version="1.1">
+  <defs>
+    <link href="github-corner-right.css" type="text/css" rel="stylesheet" xmlns="http://www.w3.org/1999/xhtml"/>
+  </defs>
+  <path d="M0 0l115 115h15l12 27 108 108V0z" fill="param(fill)"/>
+  <path class="octo-arm" d="M128 109c-15-9-9-19-9-19 3-7 2-11 2-11-1-7 3-2 3-2 4 5 2 11 2 11-3 10 5 15 9 16" fill="#fff" style="-webkit-transform-origin: 130px 106px; transform-origin: 130px 106px"/>
+  <path class="octo-body" d="M115 115s4 2 5 0l14-14c3-2 6-3 8-3-8-11-15-24 2-41 5-5 10-7 16-7 1-2 3-7 12-11 0 0 5 3 7 16 4 2 8 5 12 9s7 8 9 12c14 3 17 7 17 7-4 8-9 11-11 11 0 6-2 11-7 16-16 16-30 10-41 2 0 3-1 7-5 11l-12 11c-1 1 1 5 1 5z" fill="#fff"/>
+</svg>

--- a/source/_static/github-corner-right.txt
+++ b/source/_static/github-corner-right.txt
@@ -1,0 +1,24 @@
+
+<!--
+  https://github.com/tholman/github-corners#master#e5837dfa1
+
+  https://raw.githubusercontent.com/tholman/github-corners/master/svg/github-corner-right.svg
+
+  The MIT License (MIT)
+
+  Copyright (c) 2016 Tim Holman
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+  CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+  DEALINGS IN THE SOFTWARE.
+
+ -->

--- a/source/_static/spinaldoc.css
+++ b/source/_static/spinaldoc.css
@@ -1,0 +1,81 @@
+
+.doc-version-warning-banner {
+ background: #b0b0b0;
+ border: black 1px solid;
+ padding: 0.2em;
+ border-radius: 5px;
+ color: black;
+}
+
+/*
+.doc-version-warning-banner > a:visited {
+ color: #9b59b6;
+}
+*/
+
+footer p {
+ /* overrides theme.css:6 setting this to 12px */
+ margin-bottom: 0.5em;
+}
+
+.doc-footer-current-version {
+ /* balances the 'footer P{margin-bottom: 0.5em;}' use because the Sphinx version
+  * info from the template is not in a P block */
+ margin-top: 0.5em;
+}
+
+dialog#doc-dialog-version {
+ display: block;
+ position: fixed;
+ left: 1em;
+ right: auto;
+ bottom: 5em;
+ height: -webkit-fit-content;
+ width: -webkit-fit-content;
+ color: -internal-light-dark(black, white);
+ margin: auto;
+ border-width: initial;
+ border-style: solid;
+ border-color: initial;
+ border-image: initial;
+ border-radius: 1em;
+ padding: 1em;
+ background: -internal-light-dark(white, black);
+ width: 20em;
+ /* z-index below nav sidebar version selector */
+ z-index: 300;
+}
+
+/* .hide-once prevents unwanted flicker on page reload */
+.hide, .hide-once {
+ visibility: hidden;
+}
+
+/* .hide-once prevents unwanted flicker on page reload */
+.collapse, .collapse-once {
+ visibility: collapse;
+}
+
+object.svg-github-corner > svg {
+}
+
+.img-github-corner {
+  max-width: 149px;
+}
+
+.github-corner-abs {
+ position: fixed;
+ right: 0;
+ top: 0;
+ z-index: 150;
+}
+
+/* follows nav sidebar removal */
+@media (max-width:768px) {
+ .github-corner-abs {
+  visibility: hidden;
+ }
+ dialog#doc-dialog-version {
+  visibility: hidden;
+ }
+}

--- a/source/_templates/footer.html
+++ b/source/_templates/footer.html
@@ -1,0 +1,20 @@
+{% extends "!footer.html" %}
+{% block extrafooter %}
+    {{ super() }}
+    <!-- source/_templates/footer.html -->
+    {%- if current_version %}
+    {# Version: latest (v1.8.0) git~abcdef01 2023-02-01  all from git information #}
+    <div class="doc-footer-current-version"><p>
+    {# This data is setup in source/conf.py:html_context_add_git(attr) #}
+    {%- set thisref = git_refs[current_version.name] -%}
+    {%- if thisref -%}
+    {%- if thisref['alias'] -%}
+    {%- set current_version_alias = ' (' + thisref['alias']|join(', ') + ')' -%}
+    {%- endif -%}
+    {%- set commitid = ' git~' + thisref['format:h'] -%}
+    {%- set commitdate = ' ' + thisref['format:cs'] -%}
+    {%- endif -%}
+    Version: {{ current_version.name|e }}{{ current_version_alias|e }}{{ commitid|e }}{{ commitdate|e }}
+    </p></div>
+    {% endif %}
+{% endblock %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -15,10 +15,6 @@
     {% endif %}
     {% endfor %}
 {% endblock %}
-{% block scripts %}
-    {{ super() }}
-    <script src="{{ pathto('_static/dialog.js', 1) }}"></script>
-{% endblock %}
 {% block extrabody %}
     {{ super() }}
     {% if hasdoc(pagename) %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -1,0 +1,42 @@
+{% extends "!layout.html" %}
+
+{% if page_source_suffix %}
+{% set suffix = page_source_suffix %}
+{% else %}
+{% set suffix = source_suffix %}
+{% endif %}
+
+{% block extrahead %}
+    {{ super() }}
+    <!-- source/_templates/layout.html -->
+    {% for key,value in head_meta.items() %}
+    {% if value %}
+    <meta http-equiv="{{ key|e }}" content="{{ value|e }}">
+    {% endif %}
+    {% endfor %}
+{% endblock %}
+{% block scripts %}
+    {{ super() }}
+    <script src="{{ pathto('_static/dialog.js', 1) }}"></script>
+{% endblock %}
+{% block extrabody %}
+    {{ super() }}
+    {% if hasdoc(pagename) %}
+    {% if display_github %}
+    {% if check_meta and 'github_url' in meta %}
+    <div class="div-svg-github-corner github-corner-abs">
+    <!-- User defined GitHub URL -->
+    <a href="{{ meta['github_url'] }}" class="github-corner github-fork-ribbon" aria-label="Edit me on GitHub" data-ribbon="Edit me on GitHub" title="Edit me on GitHub">
+      <object id="svg-github-corner" data="{{ pathto('_static/github-corner-right.svg', 1) }}" class="svg-github-corner github-corner-abs" width="80" height="80"></object>
+    </a>
+    </div>
+    {% else %}
+    <div class="div-svg-github-corner github-corner-abs">
+    <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="github-corner github-fork-ribbon" aria-label="Edit on GitHub" data-ribbon="Edit on GitHub" title="Edit on GitHub">
+      <object id="svg-github-corner" data="{{ pathto('_static/github-corner-right.svg', 1) }}" class="svg-github-corner github-corner-abs" width="80" height="80"></object>
+    </a>
+    </div>
+    {% endif %}
+    {% endif %}
+    {% endif %}
+{% endblock %}

--- a/source/_templates/page.html
+++ b/source/_templates/page.html
@@ -1,0 +1,42 @@
+{% extends "!page.html" %}
+{% block body %}
+
+{%- if current_version and latest_version -%}
+
+{%- set dialog_default_state = 'close' -%}
+{%- if current_version and latest_version and current_version != latest_version and current_version.name != 'latest' -%}
+{%- set dialog_default_state = 'show' -%}
+{%- endif -%}
+
+<dialog id="doc-dialog-version" role="dialog" class="collapse-once" aria-modal="false" data-default-state="{{ dialog_default_state }}" data-current-version="{{ current_version.name|e }}" data-latest-version="{{ latest_version.name|e }}">
+<p class="doc-version-warning-banner">
+  <strong>
+    {% if current_version.is_released %}
+    You're reading an old version of this documentation.<br/>
+    For the latest stable release version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    {% elif current_version.name == 'master' %}
+    You're reading an pre-release version of this documentation.<br/>
+    For the latest stable release version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    {% elif sphinx_extra_version and current_version.name == sphinx_extra_version %}
+    You're reading the documentation for a latest stable version {{current_version.name}}.<br/>
+    {% elif sphinx_latest_version and current_version.name == sphinx_latest_version %}
+    You're reading the documentation for a latest stable version {{current_version.name}}.<br/>
+    {% elif current_version and latest_version and current_version == latest_version %}
+    You're reading the documentation for a latest stable version {{current_version.name}}.<br/>
+    {% else %}
+    You're reading the documentation for a development version.<br/>
+    For the latest stable release version, please have a look at <a href="{{ vpathto(latest_version.name) }}">{{latest_version.name}}</a>.
+    {% endif %}
+  </strong>
+  <div>
+    <form>
+      <button formmethod="dialog" type="submit" class="doc-dialog-dismiss" aria-label="close">Dismiss</button>
+    </form>
+  </div>
+</p>
+</dialog>
+
+{% endif %}
+
+{{ super() }}
+{% endblock %}%

--- a/source/_templates/versions.html
+++ b/source/_templates/versions.html
@@ -6,6 +6,17 @@
     <span class="fa fa-caret-down"></span>
   </span>
   <div class="rst-other-versions">
+    {%- if True %}
+    <dl>
+       <dt>Languages</dt>
+       <dd class="rtd-current-item">
+         <a href="#">en</a>
+       </dd>
+       <dd>
+         <a href="https://thucgra.github.io/SpinalHDL_Chinese_Doc/">zh_CN</a>
+      </dd>
+    </dl>
+    {%- endif %}
     {%- if versions.tags %}
     <dl>
       <dt>Tags</dt>

--- a/source/conf.py
+++ b/source/conf.py
@@ -216,6 +216,8 @@ html_context = {
     'github_repo': os.getenv('GITHUB_REPOSITORY_NAME', 'SpinalDoc-RTD'), # Repo name
     'github_version': os.getenv('GITHUB_REF_NAME', 'master'), # Version
     'conf_py_path': '/source/', # Path in the checkout to the docs root
+
+    'sphinx_latest_version': os.getenv('sphinx_latest_version', None)
 }
 
 #This is a temporary fix for wavedrom
@@ -227,14 +229,20 @@ linkcheck_anchors=False
 # Whitelist pattern for tags (set to None to ignore all tags)
 smv_tag_whitelist = r'^.*$'
 
+# The branch called "latest" is not a real branch/tag, it is aliased by the document
+#  build process to the most recent stable release.
 # Whitelist pattern for branches (set to None to ignore all branches)
-smv_branch_whitelist = r'^(master|dev)$'
+smv_branch_whitelist = r'^(master|dev|latest)$'
 
 # Whitelist pattern for remotes (set to None to use local branches only)
 smv_remote_whitelist = r'^.*$'
 
+# The suggested documented default pattern does not work in all scenarios, local,
+#  github clone, github original repository project locations.
 # Pattern for released versions
-smv_released_pattern = r'^tags/.*$'
+#smv_released_pattern = r'/?tags/v\d+.*'
+#smv_released_pattern = r'v\d+.*'
+smv_released_pattern = r'.*/?tags/v\d+.*$'
 
 # Format for versioned output directories inside the build directory
 smv_outputdir_format = '{ref.name}'

--- a/source/conf.py
+++ b/source/conf.py
@@ -201,12 +201,17 @@ html_theme_options = {
     'titles_only': False
 }
 
+html_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+    'gh-fork-ribbon.css',
+    'spinaldoc.css'
+]
+
+html_js_files = [
+    'dialog.js'
+]
+
 html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        '_static/gh-fork-ribbon.css',
-        '_static/spinaldoc.css'
-    ],
     'head_meta': {
         'robots': os.getenv('sphinx_html_context_head_meta_robots', None)
     },

--- a/source/conf.py
+++ b/source/conf.py
@@ -14,13 +14,14 @@
 #
 import os
 import sys
+import datetime
 # sys.path.insert(0, os.path.abspath('.'))
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'SpinalHDL'
-copyright = '2022, SpinalHDL'
+copyright = '2018 - ' + str(datetime.date.today().year) + ', SpinalHDL'
 author = 'SpinalHDL contributors'
 
 # The short X.Y version

--- a/source/conf.py
+++ b/source/conf.py
@@ -13,7 +13,7 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 import os
-# import sys
+import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
 
@@ -42,7 +42,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinxcontrib.wavedrom',
     'sphinx_multiversion',
-    'sphinx.ext.imgconverter',
+    'sphinx.ext.imgconverter'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -253,3 +253,13 @@ smv_build_targets = {
 
 # Flag indicating whether the intermediate build directories should be removed after artefacts are produced
 smv_clean_intermediate_files = True
+
+# This is in the project as bin/convert-wrapper, check we are setup correctly.
+have_image_converter = subprocess.call(['which', 'convert-wrapper'],
+                       stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) == 0
+if have_image_converter:
+    image_converter='convert-wrapper'
+else:
+    print("ERROR: convert-wrapper not found in $PATH, did you: source $PWD/bin/setup_env.sh", file=sys.stderr)
+    sys.exit(1)
+

--- a/source/conf.py
+++ b/source/conf.py
@@ -245,6 +245,11 @@ smv_build_targets = {
         "downloadable": False,
         "download_format": "",
     },
+    "SingleHTML" : {
+        "builder": "singlehtml",
+        "downloadable": True,
+        "download_format": "zip",
+    },
     "PDF" : {
         "builder": "latexpdf",
         "downloadable": True,

--- a/source/conf.py
+++ b/source/conf.py
@@ -204,8 +204,19 @@ html_theme_options = {
 html_context = {
     'css_files': [
         '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+        '_static/gh-fork-ribbon.css',
+        '_static/spinaldoc.css'
+    ],
+    'head_meta': {
+        'robots': os.getenv('sphinx_html_context_head_meta_robots', None)
+    },
+    'display_github': bool(os.getenv('sphinx_github_url', '') != ''),
+    'github_url': os.getenv('sphinx_github_url', ''), # Single URL method (not used)
+    'github_user':  os.getenv('GITHUB_REPOSITORY_OWNER', 'SpinalHDL'), # Username
+    'github_repo': os.getenv('GITHUB_REPOSITORY_NAME', 'SpinalDoc-RTD'), # Repo name
+    'github_version': os.getenv('GITHUB_REF_NAME', 'master'), # Version
+    'conf_py_path': '/source/', # Path in the checkout to the docs root
+}
 
 #This is a temporary fix for wavedrom
 online_wavedrom_js_url = "https://cdnjs.cloudflare.com/ajax/libs/wavedrom/2.6.8"

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,7 +12,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
+import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
@@ -179,9 +179,12 @@ epub_title = project
 epub_exclude_files = ['search.html']
 
 
+html_baseurl = os.getenv('sphinx_html_baseurl', '')
+
 # -- Extension configuration -------------------------------------------------
 html_theme_options = {
-    'canonical_url': '',
+    # canonical_url is deprecated for html_baseurl
+    'canonical_url': os.getenv('sphinx_canonical_url', ''),
     'analytics_id': '',
     'logo_only': False,
     'display_version': True,


### PR DESCRIPTION
 *  meta: canonical added
 *  meta: robots added (for test builds, google ignore)
 *  building 'latest' label as alias to v1.8.0
 *  bottom: Version info line
 *  github-action builder updates (param stuff, build multiversion)
 *  github-action deploy works on local fork
 *  top right 'fork me on github'
 *  left side version warning box (dismisses for 24h, URL param override)
 *  CSS attempt for narrow/mobile compat
 * CI building using a single script for all modes

Needs testing in production.

Then setup of 'on schedule' to autobuild and publish every month, to counter 3 monthly gh-pages retention policy.
Note the default setup will run the linkcheck which may fail at the time of the 'on schedule' maybe skipping linkcheck for the 'on schedule' is more appropriate to recreate the last version as-is.
