### PR TITLE
Clarify subdivide

### DIFF
--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -6,7 +6,8 @@ UInt/SInt
 Description
 -----------
 
-The ``UInt``/``SInt`` type corresponds to a vector of bits that can be used for signed/unsigned integer arithmetic.
+The ``UInt``/``SInt`` types are a vectors of bits interpreted as two's complement unsigned/signed integers.
+They can do what ``Bits`` can do, with the addition of unsigned/signed integer arithmetic and comparisons.
 
 Declaration
 -----------
@@ -15,43 +16,33 @@ The syntax to declare an integer is as follows:  (everything between [] is optio
 
 .. list-table::
    :header-rows: 1
-   :widths: 5 10 2
+   :widths: 5 10
 
    * - Syntax
      - Description
-     - Return
    * - | UInt[()]
        | SInt[()]
      - Create an unsigned/signed integer, bits count is inferred
-     - | UInt
-       | SInt
    * - | UInt(x bits)
        | SInt(x bits)
      - Create an unsigned/signed integer with x bits
-     - | UInt
-       | SInt
    * - | U(value: Int[,x bits])
        | U(value: BigInt[,x bits])
        | S(value: Int[,x bits])
        | S(value: BigInt[,x bits])
      - Create an unsigned/signed integer assigned with 'value'
-     - | UInt
-       | SInt
    * - | U"[[size']base]value"
        | S"[[size']base]value"
-     - Create an unsigned/signed integer assigned with 'value' (Base : 'h', 'd', 'o', 'b')
-     - | UInt
-       | SInt
-   * - | U([x bits,] :ref:`element <element>`, ...)
-       | S([x bits,] :ref:`element <element>`, ...)
-     - Create an unsigned integer assigned with the value specified by elements
-     - | UInt
-       | SInt
+     - | Create an unsigned/signed integer assigned with 'value'
+       | (base: 'h', 'd', 'o', 'b')
+   * - | U([x bits,] elements: Element*)
+       | S([x bits,] elements: Element*)
+     - Create an unsigned integer assigned with the value specified by :ref:`elements <element>`
 
 .. code-block:: scala
 
-   val myUInt = UInt(8 bits)
-   myUInt := U(2,8 bits)
+   val myUInt = UInt(8 bit)
+   myUInt := U(2, 8 bit)
    myUInt := U(2)
    myUInt := U"0000_0101"  // Base per default is binary => 5
    myUInt := U"h1A"        // Base could be x (base 16)
@@ -63,10 +54,12 @@ The syntax to declare an integer is as follows:  (everything between [] is optio
    myUInt := 2             // You can use a Scala Int as a literal value
 
    val myBool = Bool()
-   myBool := myUInt === U(7 -> true,(6 downto 0) -> false)
+   myBool := myUInt === U(7 -> true, (6 downto 0) -> false)
+   myBool := myUInt === U(8 bit, 7 -> true, default -> false)
    myBool := myUInt === U(myUInt.range -> true)
 
-   // For assignment purposes, you can omit the U/S, which also allows the use of the [default -> ???] feature
+   // For assignment purposes, you can omit the U/S
+   // which also allows the use of "default -> ???"
    myUInt := (default -> true)                        // Assign myUInt with "11111111"
    myUInt := (myUInt.range -> true)                   // Assign myUInt with "11111111"
    myUInt := (7 -> true, default -> false)            // Assign myUInt with "10000000"
@@ -136,25 +129,25 @@ Logic
      - T(w(x) bits)
    * - x.clearAll[()]
      - Clear all bits
-     - 
+     - *modifies x*
    * - x.setAll[()]
      - Set all bits
-     - 
+     - *modifies x*
    * - x.setAllTo(value : Boolean)
      - Set all bits to the given Boolean value
-     - 
+     - *modifies x*
    * - x.setAllTo(value : Bool)
      - Set all bits to the given Bool value
-     - 
+     - *modifies x*
 
 .. note::
 
-   Notice the difference in behaviour between ``x >> 2``:T(w(x)-2) and ``x >> U(2)``:T(w(x))
+   Notice the difference in behaviour between ``x >> 2`` (result 2 bit narrower than x) and ``x >> U(2)`` (keeping width)
    due to the Scala type of :code:`y`.
 
-   The difference is that in the first case 2 is an ``Int`` (which can be seen as an
+   In the first case "2" is an ``Int`` (which can be seen as an
    "elaboration integer constant"), and in the second case it is a hardware signal
-   (type ``UInt``) that may or may-not be a constant.
+   (type ``UInt``) that may or may not be a constant.
 
 .. code-block:: scala
 
@@ -234,6 +227,7 @@ Arithmetic
    val d = a +^ b
    assert(d === U"9'x0ff")
 
+   // 0xf0 + 0x20 would overflow, the result therefore saturates
    val e = a +| U"8'x20"
    assert(e === U"8'xff")
 
@@ -542,7 +536,7 @@ to use the return values to assign to the original signal.
 
    // Concatenation
    val mySInt = mySInt_1 @@ mySInt_1 @@ myBool   
-   val myBits = mySInt_1 ## mySInt_1 ## myBool   
+   val myBits = mySInt_1 ## mySInt_1 ## myBool
 
    // Resize
    myUInt_32bits := U"32'x112233344"

--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -4,12 +4,12 @@ UInt/SInt
 =========
 
 Description
-^^^^^^^^^^^
+-----------
 
 The ``UInt``/``SInt`` type corresponds to a vector of bits that can be used for signed/unsigned integer arithmetic.
 
 Declaration
-^^^^^^^^^^^
+-----------
 
 The syntax to declare an integer is as follows:  (everything between [] is optional)
 
@@ -73,12 +73,12 @@ The syntax to declare an integer is as follows:  (everything between [] is optio
    myUInt := ((4 downto 1) -> true, default -> false) // Assign myUInt with "00011110"
 
 Operators
-^^^^^^^^^
+---------
 
 The following operators are available for the ``UInt`` and ``SInt`` types:
 
 Logic
-~~~~~
+^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -180,7 +180,7 @@ Logic
    when(a.andR) { b.setAll() }
 
 Arithmetic
-~~~~~~~~~~
+^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -243,7 +243,7 @@ Arithmetic
    assertions in the previous example (with ``==``).
 
 Comparison
-~~~~~~~~~~
+^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -292,7 +292,7 @@ Comparison
    The ``wrap`` method of ``UInt`` can be used as ``x.wrap < y`` for ``UInt`` variables ``x, y``, the result will be true if ``x`` is less than ``y`` in the wraparound sense.
 
 Type cast
-~~~~~~~~~
+^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -339,7 +339,7 @@ To cast a ``Bool``, a ``Bits``, or an ``SInt`` into a ``UInt``, you can use ``U(
    val mySInt = S(myBits)
 
 Bit extraction
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -383,7 +383,7 @@ Bit extraction
    mySInt_8bits(3 downto 0) := mySInt_4bits
 
 Misc
-~~~~
+^^^^
 
 .. list-table::
    :header-rows: 1
@@ -491,15 +491,9 @@ Misc
    myUInt_8bits  := myUInt_32bits.resized       // automatic resize (myUInt_8bits = 0x44)
    val lowest_8bits = myUInt_32bits.resize(8)  // resize to 8 bits (myUInt_8bits = 0x44)
 
-   // Two's complement
-   mySInt := myUInt.twoComplement(myBool)
-
-   // Absolute value
-   mySInt_abs := mySInt.abs
-
 
 FixPoint operations
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 For fixpoint, we can divide it into two parts:
 
@@ -507,7 +501,7 @@ For fixpoint, we can divide it into two parts:
  - High bit operations (saturation operations)
 
 Lower bit operations
-~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^
 
 .. image:: /asset/image/fixpoint/lowerBitOperation.png
 
@@ -590,7 +584,7 @@ You will find `ROUNDUP`, `ROUNDDOWN`, `ROUNDTOZERO`, `ROUNDTOINF`, `ROUNDTOEVEN`
    As a result, ``roundUp`` is strongly recommended for production use.
 
 High bit operations
-~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^
 
 .. image:: /asset/image/fixpoint/highBitOperation.png
 
@@ -615,7 +609,7 @@ Symmetric is only valid for ``SInt``.
    val C  = A.sat(3).symmetry  // return 5 bits and symmetry as (-16~15 to -15~15)
 
 fixTo function
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 Two ways are provided in ``UInt``/``SInt`` to do fixpoint:
 

--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -3,10 +3,7 @@
 UInt/SInt
 =========
 
-Description
------------
-
-The ``UInt``/``SInt`` types are a vectors of bits interpreted as two's complement unsigned/signed integers.
+The ``UInt``/``SInt`` types are vectors of bits interpreted as two's complement unsigned/signed integers.
 They can do what ``Bits`` can do, with the addition of unsigned/signed integer arithmetic and comparisons.
 
 Declaration
@@ -402,13 +399,13 @@ the extraction operators can also be used to assign a part of a ``UInt`` / ``SIn
      - Subdivide x in multiple slices of y bits, y: Int
      - Vec(Bits(y bit), ...)
    * - x.msb
-     - Access most significant bit of x (highest index)
+     - Access most significant bit of x (highest index, sign bit for SInt)
      - Bool
    * - x.lsb
      - Access lowest significant bit of x (index 0)
      - Bool
    * - mySInt.sign
-     - Access most significant (sign) bit
+     - Access most sign bit, only SInt
      - Bool
 
 
@@ -445,8 +442,8 @@ Subdivide details
 """""""""""""""""
 
 Both overloads of ``subdivideIn`` have an optional parameter ``strict`` (i.e. ``subdivideIn(slices: SlicesCount, strict: Boolean = true)``).
-If ``strict`` is ``true`` an error will be raised if the input could not be divided evenly. If set to ``false`` the generated pieces may
-have varying size if necessary.
+If ``strict`` is ``true`` an error will be raised if the input could not be divided into equal parts. If set to ``false`` the last element may
+be smaller than the other (equal sized) elements.
 
 .. code-block:: scala
 
@@ -472,7 +469,6 @@ have varying size if necessary.
 Misc
 ^^^^
 
-The operations listed below that create hardware signals all create new signals.
 In contrast to the bit extraction operations listed above it's not possible
 to use the return values to assign to the original signal.
 

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -320,8 +320,8 @@ Subdivide details
 """""""""""""""""
 
 Both overloads of ``subdivideIn`` have an optional parameter ``strict`` (i.e. ``subdivideIn(slices: SlicesCount, strict: Boolean = true)``).
-If ``strict`` is ``true`` an error will be raised if the input could not be divided evenly. If set to ``false`` the generated pieces may
-have varying size if necessary.
+If ``strict`` is ``true`` an error will be raised if the input could not be divided into equal parts. If set to ``false`` the last element may
+be smaller than the other (equal sized) elements.
 
 .. code-block:: scala
 
@@ -347,7 +347,6 @@ have varying size if necessary.
 Misc
 ^^^^
 
-The operations listed below that create hardware signals all create new signals.
 In contrast to the bit extraction operations listed above it's not possible
 to use the return values to assign to the original signal.
 

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -58,7 +58,7 @@ The syntax to declare a bit vector is as follows: (everything between [] is opti
    // Element
    val myBits5 = B(8 bits, default -> True) // "11111111"
    val myBits6 = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false) // "10111000"
-   val myBits7 = Bits(8 bits)
+   val myBits7 = Bits(8 bits)
    myBits7 := (7 -> true, default -> false) // "10000000" (For assignment purposes, you can omit the B)
 
 Operators
@@ -397,7 +397,7 @@ to use the return values to assign to the original signal.
   type which uses `Int`)
 
 .. code-block:: scala
-
+   
    println(myBits_32bits.getWidth) // 32
 
    // Concatenation
@@ -416,7 +416,8 @@ to use the return values to assign to the original signal.
 MaskedLiteral
 -------------
 
-MaskedLiteral values are bit vectors with don’t care values denoted with `-`.
+MaskedLiteral values are bit vectors with don't care values denoted with ``-``.
+They can be used for direct comparison or for ``switch`` statements and ``mux`` es.
 
 .. code-block:: scala
 

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -38,15 +38,6 @@ The syntax to declare a bit vector is as follows: (everything between [] is opti
 
 .. code-block:: scala
 
-   // Declaration
-   val myBits  = Bits()     // the size is inferred from the widest assignment
-   // ....
-   // .resized needed to prevent WIDTH MISMATCH error as natural width does not match inferred size
-   myBits := B("1010").resized  // auto-widen Bits(4 bits) to Bits(6 bits)
-   when(condxMaybe) {
-     myBits := B("110000")      // Bits(6 bits) would be inferred for myBits, this is the widest assignment
-   }
-
    val myBits1 = Bits(32 bits)   
    val myBits2 = B(25, 8 bits)
    val myBits3 = B"8'xFF"   // Base could be x,h (base 16)                         
@@ -55,11 +46,31 @@ The syntax to declare a bit vector is as follows: (everything between [] is opti
                             //               b   (base 2)    
    val myBits4 = B"1001_0011"  // _ can be used for readability
 
-   // Element
-   val myBits5 = B(8 bits, default -> True) // "11111111"
-   val myBits6 = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false) // "10111000"
+   // Bits with all ones ("11111111")
+   val myBits5 = B(8 bits, default -> True)
+
+   // initialize with "10111000" through a few elements
+   val myBits6 = B(8 bits, (7 downto 5) -> B"101", 4 -> true, 3 -> True, default -> false)
+
+   // "10000000" (For assignment purposes, you can omit the B)
    val myBits7 = Bits(8 bits)
-   myBits7 := (7 -> true, default -> false) // "10000000" (For assignment purposes, you can omit the B)
+   myBits7 := (7 -> true, default -> false) 
+
+When inferring the width of a ``Bits`` the sizes of assigned values still have to match 
+the final size of the signal:
+
+.. code-block:: scala
+
+   // Declaration
+   val myBits = Bits()     // the size is inferred from the widest assignment
+   // ....
+   // .resized needed to prevent WIDTH MISMATCH error as the constants
+   // width does not match size that is inferred from assignment below
+   myBits := B("1010").resized  // auto-widen Bits(4 bits) to Bits(6 bits)
+   when(condxMaybe) {
+     // Bits(6 bits) is inferred for myBits, this is the widest assignment
+     myBits := B("110000")
+   }
 
 Operators
 ---------

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -334,10 +334,10 @@ have varying size if necessary.
    // Subdivide
    val sel = UInt(2 bits)
    val myBitsWord = myBits_128bits.subdivideIn(32 bits)(sel)
-       // sel = 0 => myBitsWord = myBits_128bits(127 downto 96)
-       // sel = 1 => myBitsWord = myBits_128bits( 95 downto 64)
-       // sel = 2 => myBitsWord = myBits_128bits( 63 downto 32)
-       // sel = 3 => myBitsWord = myBits_128bits( 31 downto  0)
+       // sel = 3 => myBitsWord = myBits_128bits(127 downto 96)
+       // sel = 2 => myBitsWord = myBits_128bits( 95 downto 64)
+       // sel = 1 => myBitsWord = myBits_128bits( 63 downto 32)
+       // sel = 0 => myBitsWord = myBits_128bits( 31 downto  0)
 
     // If you want to access in reverse order you can do:
     val myVector   = myBits_128bits.subdivideIn(32 bits).reverse

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -3,13 +3,10 @@
 Bits
 ====
 
-Description
-^^^^^^^^^^^
-
-The ``Bits`` type corresponds to a vector of bits that does not convey any arithmetic meaning.
+The ``Bits`` type represents a vector of bits without conveying any arithmetic meaning.
 
 Declaration
-^^^^^^^^^^^
+-----------
 
 The syntax to declare a bit vector is as follows: (everything between [] is optional)
 
@@ -65,12 +62,12 @@ The syntax to declare a bit vector is as follows: (everything between [] is opti
    myBits7 := (7 -> true, default -> false) // "10000000" (For assignment purposes, you can omit the B)
 
 Operators
-^^^^^^^^^
+---------
 
 The following operators are available for the ``Bits`` type:
 
 Logic
-~~~~~
+^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -171,7 +168,7 @@ Logic
    }
 
 Comparison
-~~~~~~~~~~
+^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -196,7 +193,7 @@ Comparison
    }
 
 Type cast
-~~~~~~~~~
+^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -242,7 +239,7 @@ To cast a ``Bool``, ``UInt`` or an ``SInt`` into a ``Bits``, you can use ``B(som
    val myBits = B(mySInt, 3 bits)
 
 Bit extraction
-~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -287,7 +284,7 @@ Bit extraction
    myBits_8bits(3 downto 0) := myBits_4bits
 
 Misc
-~~~~
+^^^^
 
 .. list-table::
    :header-rows: 1
@@ -382,7 +379,7 @@ Misc
 .. _maskedliteral:
 
 MaskedLiteral
-~~~~~~~~~~~~~~
+-------------
 
 MaskedLiteral values are bit vectors with don’t care values denoted with `-`.
 

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -241,50 +241,110 @@ To cast a ``Bool``, ``UInt`` or an ``SInt`` into a ``Bits``, you can use ``B(som
 Bit extraction
 ^^^^^^^^^^^^^^
 
+All of the bit extraction operations can be used to read a bit / group of bits. Like in other HDLs
+the extraction operators can also be used to assign a part of a ``Bits``.
+
+All of the bit extraction operations can be used to read a bit / group of bits. Like in other HDLs They
+can also be used to select a range of bits to be written.
+
 .. list-table::
    :header-rows: 1
-   :widths: 2 5 2
+   :widths: 3 5 2
 
    * - Operator
      - Description
      - Return
-   * - x(y)
-     - Readbit, y: Int/UInt
+   * - x(y: Int)
+     - Static bit access of y-th bit
      - Bool
-   * - x(offset,width bits)
-     - Read bitfield, offset: UInt, width: Int
-     - Bits(width bits)
-   * - x(\ :ref:`range <range>`\ )
-     - Read a range of bit. Ex : myBits(4 downto 2)
-     - Bits(range bits)
-   * - x(y) := z
-     - Assign a single bit, y: Int/UInt
+   * - x(x: UInt)
+     - Variable bit access of y-th bit
      - Bool
-   * - x(offset, width bits) := z
-     - Assign bitfield, offset: UInt, width: Int
+   * - x(offset: Int, width bits)
+     - Fixed part select of fixed width, offset is LSB index
      - Bits(width bits)
-   * - x(\ :ref:`range <range>`\ ) := z
-     - Assign a range of bits. Ex : myBits(4 downto 2) := B"010"
-     - Bits(range bits)
+   * - x(offset: UInt, width bits)
+     - Variable part-select of fixed width, offset is LSB index
+     - Bits(width bits)
+   * - x(range: Range)
+     - Access a :ref:`range <range>` of bits. Ex : myBits(4 downto 2)
+     - Bits(range.size bits)
+   * - x.subdivideIn(y slices, [strict: Boolean])
+     - Subdivide x into y slices, y: Int
+     - Vec(Bits, y)
+   * - x.subdivideIn(y bits, [strict: Boolean])
+     - Subdivide x in multiple slices of y bits, y: Int
+     - Vec(Bits, ...)
+   * - x.msb
+     - Access most significant bit of x (highest index)
+     - Bool
+   * - x.lsb
+     - Access lowest significant bit of x (index 0)
+     - Bool
 
+
+Some basic examples:
 
 .. code-block:: scala
 
    // get the element at the index 4
    val myBool = myBits(4)
-
-   // assign
+   // assign element 1
    myBits(1) := True
 
-   // Range
-   val myBits_8bits = myBits_16bits(7 downto 0)
-   val myBits_7bits = myBits_16bits(0 to 6)
-   val myBits_6bits = myBits_16Bits(0 until 6)
+   // index dynamically
+   val index = UInt(2 bit)
+   val indexed = myBits(index, 2 bit)
 
-   myBits_8bits(3 downto 0) := myBits_4bits
+   // range index
+   val myBits_8bit = myBits_16bit(7 downto 0)
+   val myBits_7bit = myBits_16bit(0 to 6)
+   val myBits_6bit = myBits_16bit(0 until 6)
+   // assign to myBits_16bit(3 downto 0)
+   myBits_8bit(3 downto 0) := myBits_4bit
+
+   // equivalent slices, no reversing occurs
+   val a = myBits_16bit(8 downto 4)
+   val b = myBits_16bit(4 to 8)
+
+   // read / assign the msb / leftmost bit / x.high bit
+   val isNegative = myBits_16bit.msb
+   myBits_16bit.msb := False
+
+Subdivide details
+"""""""""""""""""
+
+Both overloads of ``subdivideIn`` have an optional parameter ``strict`` (i.e. ``subdivideIn(slices: SlicesCount, strict: Boolean = true)``).
+If ``strict`` is ``true`` an error will be raised if the input could not be divided evenly. If set to ``false`` the generated pieces may
+have varying size if necessary.
+
+.. code-block:: scala
+
+   // Subdivide
+   val sel = UInt(2 bits)
+   val myBitsWord = myBits_128bits.subdivideIn(32 bits)(sel)
+       // sel = 0 => myBitsWord = myBits_128bits(127 downto 96)
+       // sel = 1 => myBitsWord = myBits_128bits( 95 downto 64)
+       // sel = 2 => myBitsWord = myBits_128bits( 63 downto 32)
+       // sel = 3 => myBitsWord = myBits_128bits( 31 downto  0)
+
+    // If you want to access in reverse order you can do:
+    val myVector   = myBits_128bits.subdivideIn(32 bits).reverse
+    val myBitsWord = myVector(sel)
+
+    // We can also assign through subdivides
+    val output8 = Bits(8 bit)
+    val pieces = someOutput.subdivideIn(2 slices)
+    // assign to output8
+    pieces(0) := 0xf
+    pieces(1) := 0x5
 
 Misc
 ^^^^
+
+The operations listed below that create hardware signals all create new signals.
+In contrast to the bit extraction operations listed above it's not possible
+to use the return values to assign to the original signal.
 
 .. list-table::
    :header-rows: 1
@@ -303,27 +363,14 @@ Misc
      - Return the range of minimum to maximum x values, interpreted as an unsigned integer (0 to 2 \*\* width - 1).
      - Range
    * - x.high
-     - Return the index of the MSB (highest allowed zero-based index for Bits)
+     - Return the index of the MSB (highest allowed zero-based index for x)
      - Int
-   * - x.msb
-     - Return the value of the most significant bit
-     - Bool
-   * - x.lsb
-     - Return the value of the least significant bit
-     - Bool
    * - x.reversed
-     - Return a representation of the same instance in reverse bit order,
-       MSB<>LSB are mirrored.
+     - Return a copy of x with reverse bit order, MSB<>LSB are mirrored.
      - Bits(w(x) bits)
    * - x ## y
      - Concatenate, x->high, y->low
      - Bits(w(x) + w(y) bits)
-   * - x.subdivideIn(y slices)
-     - Subdivide x in y slices, y: Int
-     - Vec(Bits, y)
-   * - x.subdivideIn(y bits)
-     - Subdivide x in multiple slices of y bits, y: Int
-     - Vec(Bits, w(x)/y)
    * - x.resize(y)
      - Return a resized representation of x, if enlarged, it is extended with zero
        padding at MSB as necessary, y: Int
@@ -353,22 +400,10 @@ Misc
 
    println(myBits_32bits.getWidth) // 32
 
-   myBool := myBits.lsb  // Equivalent to myBits(0)
-
    // Concatenation
    myBits_24bits := bits_8bits_1 ## bits_8bits_2 ## bits_8bits_3
-
-   // Subdivide
-   val sel = UInt(2 bits)
-   val myBitsWord = myBits_128bits.subdivideIn(32 bits)(sel)
-       // sel = 0 => myBitsWord = myBits_128bits(127 downto 96)
-       // sel = 1 => myBitsWord = myBits_128bits( 95 downto 64)
-       // sel = 2 => myBitsWord = myBits_128bits( 63 downto 32)
-       // sel = 3 => myBitsWord = myBits_128bits( 31 downto  0)
-
-    // If you want to access in reverse order you can do:
-    val myVector   = myBits_128bits.subdivideIn(32 bits).reverse
-    val myBitsWord = myVector(sel)
+   // or
+   myBits_24bits := Cat(bits_8bits_1, bits_8bits_2, bits_8bits_3)
 
    // Resize
    myBits_32bits := B"32'x112233344"

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -8,31 +8,31 @@ The ``Bits`` type represents a vector of bits without conveying any arithmetic m
 Declaration
 -----------
 
-The syntax to declare a bit vector is as follows: (everything between [] is optional)
+The syntax to declare a bit vector is as follows (everything between [] is optional):
 
 .. list-table::
    :header-rows: 1
-   :widths: 5 10 2
+   :widths: 6 10 1
 
    * - Syntax
      - Description
      - Return
    * - Bits [()]
-     - Create a BitVector, bit count is inferred from the widest assignment statement
+     - Create Bits, bit count is inferred from the widest assignment statement
        after construction
      - Bits
    * - Bits(x bits)
-     - Create a BitVector with x bits
+     - Create Bits with x bits
      - Bits
    * - | B(value: Int[, x bits])
        | B(value: BigInt[, x bits])
-     - Create a BitVector with x bits assigned with 'value'
+     - Create Bits with x bits assigned with 'value'
      - Bits
    * - B"[[size']base]value"
-     - Create a BitVector assigned with 'value' (Base: 'h', 'd', 'o', 'b')
+     - Create Bits assigned with 'value' (base: 'h', 'd', 'o', 'b')
      - Bits
-   * - B([x bits,] :ref:`element <element>`\ , ...)
-     - Create a BitVector assigned with the value specified by elements
+   * - B([x bits,] elements: Element*)
+     - Create Bits assigned with the value specified by :ref:`elements <element>`
      - Bits
 
 
@@ -146,16 +146,16 @@ Logic
      - Bits(w(x) bits)
    * - x.clearAll[()]
      - Clear all bits
-     - 
+     - *modifies x*
    * - x.setAll[()]
      - Set all bits
-     - 
+     - *modifies x*
    * - x.setAllTo(value: Boolean)
      - Set all bits to the given Boolean value
-     - 
+     - *modifies x*
    * - x.setAllTo(value: Bool)
      - Set all bits to the given Bool value
-     - 
+     - *modifies x*
 
 .. code-block:: scala
 
@@ -198,10 +198,10 @@ Comparison
 .. code-block:: scala
 
    when(myBits === 3) {
+     // ...
    }
 
-   when(myBits_32 =/= B"32'x44332211") {
-   }
+   val notMySpecialValue = myBits_32 =/= B"32'x44332211"
 
 Type cast
 ^^^^^^^^^
@@ -260,7 +260,7 @@ can also be used to select a range of bits to be written.
 
 .. list-table::
    :header-rows: 1
-   :widths: 3 5 2
+   :widths: 2 4 2
 
    * - Operator
      - Description
@@ -282,10 +282,10 @@ can also be used to select a range of bits to be written.
      - Bits(range.size bits)
    * - x.subdivideIn(y slices, [strict: Boolean])
      - Subdivide x into y slices, y: Int
-     - Vec(Bits, y)
+     - Vec(Bits(...), y)
    * - x.subdivideIn(y bits, [strict: Boolean])
      - Subdivide x in multiple slices of y bits, y: Int
-     - Vec(Bits, ...)
+     - Vec(Bits(y bit), ...)
    * - x.msb
      - Access most significant bit of x (highest index)
      - Bool

--- a/source/SpinalHDL/Data types/bits.rst
+++ b/source/SpinalHDL/Data types/bits.rst
@@ -3,7 +3,7 @@
 Bits
 ====
 
-The ``Bits`` type represents a vector of bits without conveying any arithmetic meaning.
+The ``Bits`` type is a vector of bits without conveying any arithmetic meaning.
 
 Declaration
 -----------
@@ -12,28 +12,22 @@ The syntax to declare a bit vector is as follows (everything between [] is optio
 
 .. list-table::
    :header-rows: 1
-   :widths: 6 10 1
+   :widths: 5 10
 
    * - Syntax
      - Description
-     - Return
    * - Bits [()]
      - Create Bits, bit count is inferred from the widest assignment statement
        after construction
-     - Bits
    * - Bits(x bits)
      - Create Bits with x bits
-     - Bits
    * - | B(value: Int[, x bits])
        | B(value: BigInt[, x bits])
      - Create Bits with x bits assigned with 'value'
-     - Bits
    * - B"[[size']base]value"
      - Create Bits assigned with 'value' (base: 'h', 'd', 'o', 'b')
-     - Bits
    * - B([x bits,] elements: Element*)
      - Create Bits assigned with the value specified by :ref:`elements <element>`
-     - Bits
 
 
 .. code-block:: scala
@@ -341,11 +335,11 @@ have varying size if necessary.
 
     // If you want to access in reverse order you can do:
     val myVector   = myBits_128bits.subdivideIn(32 bits).reverse
-    val myBitsWord = myVector(sel)
+    val myRevBitsWord = myVector(sel)
 
     // We can also assign through subdivides
     val output8 = Bits(8 bit)
-    val pieces = someOutput.subdivideIn(2 slices)
+    val pieces = output8.subdivideIn(2 slices)
     // assign to output8
     pieces(0) := 0xf
     pieces(1) := 0x5


### PR DESCRIPTION
This started out just wanting to move subdivide to the access functions, but now ended in a few additional changes. Among the bigger ones that e.g. `abs` and similar functions are now listed as "conversion" functions, some additional examples and a fix to the output order of `subdivideIn` in the examples.