### PR TITLE
Update Fix.rst comparison table

### DIFF
--- a/source/SpinalHDL/Data types/Fix.rst
+++ b/source/SpinalHDL/Data types/Fix.rst
@@ -219,7 +219,7 @@ Comparison
    * - x >= y
      - Greater than or equal
      - Bool
-   * - x > y
+   * - x < y
      - Less than
      - Bool
    * - x >= y


### PR DESCRIPTION
Updated a fix for the table rappresenting the Logic operation with Fixed point. the table shows x>y twice.