### PR TITLE
add chinese version link. Should be fixed after officially merged.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,10 @@ This is the documentation repository for
 It is published on
 `spinalhdl.github.io/SpinalDoc-RTD <https://spinalhdl.github.io/SpinalDoc-RTD/master/index.html>`_.
 
+There is also a Chinese version on
+`spinalhdl-cn.github.io/SpinalDoc-RTD <https://spinalhdl-cn.github.io/SpinalDoc-RTD/zh_CN/index.html>`_. 
+This conitnuous localization version is maintained with the help of `Weblate <https://hosted.weblate.org/projects/spinaldoc-rtd/>`_.
+
 You can also find the API documentation on
 `spinalhdl.github.io/SpinalHDL <https://spinalhdl.github.io/SpinalHDL/dev/spinal/index.html>`_.
 


### PR DESCRIPTION
This is a thanks to the weblate's hosting of continuous localization.

Now the translated repos is still under SpinalHDL-CN, I still have to find a way to switch the repos link first to have all modifications merge back to upstream.