### PR TITLE
Add doc for `History(that, range)`

### DIFF
--- a/source/SpinalHDL/Getting Started/Install and setup.rst
+++ b/source/SpinalHDL/Getting Started/Install and setup.rst
@@ -128,7 +128,7 @@ Windows installation
 
 .. note::
    While a native installation is possible the simpler and currently recommended way is to use WSL on Windows.
-   If you want to use WSL, install `it <https://learn.microsoft.com/en-us/windows/wsl/install>`_, a distribution of your choice and
+   If you want to use WSL, install `it <https://learn.microsoft.com/en-us/windows/wsl/install>`__, a distribution of your choice and
    follow the Linux installation instructions. Data in your WSL instance can be accessed from windows under ``\\wsl$``.
    In case you want to use IntelliJ you'll have to download the Linux version to WSL, if you want to use VSCode then the Windows
    version can be used to remotely edit in WSL.
@@ -147,7 +147,7 @@ In case you want to build the tools yourself have a look at the legacy simulatio
 
 .. note::
    An All-in-One solution offered by SpinalHDL maintainer `Readon <https://github.com/Readon>` is available to install and run SpinalHDL with Verilator simulation and formal verification via SymbiYosys.
-   Download `it <https://github.com/Readon/msys2-installer/releases>`_ and install the environment anywhere on your disk.
+   Download `it <https://github.com/Readon/msys2-installer/releases>`__ and install the environment anywhere on your disk.
    Start the build environment by clicking on the MSYS2-MINGW64 icon in the Start menu and use the MSYS2 default console. 
    An alternative is to use the Windows Terminal or a Tabby-like application and use the startup command ``%MSYS2_ROOT%\msys2_shell.cmd -defterm -here -no-start -mingw64``, where the ``%MSYS2_ROOT%`` is the location of the msys2 installation.
    It is worth noting that if you want to use it offline, you should carefully select the libraries that the project depends on, otherwise you will need to download the packages manually.

--- a/source/SpinalHDL/Libraries/utils.rst
+++ b/source/SpinalHDL/Libraries/utils.rst
@@ -89,11 +89,23 @@ State full utilities
    * - Delay(that: T, cycleCount: Int)
      - T
      - Return ``that`` delayed by ``cycleCount`` cycles
-   * - History(that: T, length: Int[,when : Bool])
-     - List[T]
+   * - | History (
+       |   that: T, length: Int
+       |   *[*\ , when : Bool\ *][*\ , init : T\ *]*
+       | )
+     - Vec[T]
      - | Return a Vec of ``length`` elements
-       | The first element is ``that``\ , the last one is ``that`` delayed by ``length``\ -1\
+       | The first element is ``that``\ , the last one is ``that`` delayed by ``length`` - 1
        | The internal shift register sample when ``when`` is asserted
+   * - | History (
+       |   that: T, range: Range
+       |   *[*\ , when : Bool\ *][*\ , init : T\ *]*
+       | )
+     - Vec[T]
+     - | Same as ``History(that, length)`` 
+       | but return a Vec of size ``range.length``
+       | where the first element is delayed by ``range.low``
+       | and the last by ``range.high``
    * - BufferCC(input : T)
      - T
      - Return the input signal synchronized with the current clock domain by using 2 flip flop

--- a/source/SpinalHDL/Structuring/blackbox.rst
+++ b/source/SpinalHDL/Structuring/blackbox.rst
@@ -183,7 +183,8 @@ By default the ports of the blackbox are considered clock-less, meaning no clock
 You can also apply the tag to the whole bundle with : 
 
 .. code-block:: scala
-      val io = new Bundle{
+
+      val io = new Bundle {
         val clk, rst = in Bool()
         val a = in Bool()
         val b = out Bool()
@@ -193,7 +194,8 @@ You can also apply the tag to the whole bundle with :
 You can also apply the current clock domain to all the ports using (SpinalHDL 1.10.2): 
 
 .. code-block:: scala
-      val io = new Bundle{
+
+      val io = new Bundle {
         val clk, rst = in Bool()
         val a = in Bool()
         val b = out Bool()


### PR DESCRIPTION
Based on my limited understanding of [The UART workshop solution](https://github.com/SpinalHDL/SpinalWorkshop/blob/9fd30eb3071b6849ce676fb3086cc2fc22ff731e/src/main/scala/workshop/uart/assets/UartCtrlRx.solution#L34) and [spinalhdl lib code](https://github.com/SpinalHDL/SpinalHDL/blob/768f0960f581c3160c4ef14ebb03928f1f9e2db5/lib/src/main/scala/spinal/lib/Utils.scala#L1218), I updated the documentation. 

Please check that the description is valid, I'm very new to all of that.