### PR TITLE
Correct supported slave factory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Create a virtual environment with pipenv (will use the Pipfile for installing th
 
    python3 -m venv .venv
 
-then you can activate the virtual enviroment (in bash) and install the dependencies
+then you can activate the virtual environment (in bash) and install the dependencies
 
 .. code:: shell
 

--- a/source/SpinalHDL/Examples/Simple ones/sinus_rom.rst
+++ b/source/SpinalHDL/Examples/Simple ones/sinus_rom.rst
@@ -1,9 +1,9 @@
 .. _sinus_rom:
 
-Sinus rom
+Sinus ROM
 =========
 
-Let's imagine that you want to generate a sine wave and also have a filtered version of it (which is completely useless in practical, but let's do it as an example).
+Let's imagine that you want to generate a sine wave and also have a filtered version of it (which is completely useless in practice, but let's do it as an example).
 
 .. list-table::
    :header-rows: 1

--- a/source/SpinalHDL/Libraries/bus_slave_factory.rst
+++ b/source/SpinalHDL/Libraries/bus_slave_factory.rst
@@ -18,7 +18,7 @@ You can find more documentation about the internal implementation of the ``BusSl
 Functionality
 -------------
 
-| There are many implementations of the ``BusSlaveFactory`` tool : AHB3-lite, APB3, APB4, AvalonMM, AXI-lite 3, AXI4, BMB, Wishbone and PipelinedMemoryBus.
+| There are many implementations of the ``BusSlaveFactory`` tool : AHB3-lite, APB3, APB4, AvalonMM, AXI-lite 3, AXI4, BMB, Wishbone, Tilelink, BRAM bus and PipelinedMemoryBus.
 | Each implementation of that tool take as an argument one instance of the corresponding bus and then offers the following functions to map your hardware into the memory mapping :
 
 .. list-table::

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -41,7 +41,7 @@ As in VHDL and Verilog, signals can be conditionally assigned when a specified c
 
 
 WhenBuilder
-------
+-----------
 
 Sometimes we need to generate some parameters for the when condition, 
 and the original structure of when else is not very suitable. 


### PR DESCRIPTION
Based on implementations present in directory /lib/src/main/scala/spinal/lib/bus of spinalHDL v1.10.2 .