### PR TITLE
Fix spelling, typos, space before {, //

### DIFF
--- a/examples/src/main/scala/spinaldoc/examples/advanced/JTAG.scala
+++ b/examples/src/main/scala/spinaldoc/examples/advanced/JTAG.scala
@@ -27,7 +27,7 @@ class JtagFsm(jtag: Jtag) extends Area {
     val state = RegNext(stateNext) randBoot()
 
     stateNext := state.mux(
-    default    -> (jtag.tms ? RESET     | IDLE),           //RESET
+    default    -> (jtag.tms ? RESET     | IDLE),           // RESET
     IDLE       -> (jtag.tms ? DR_SELECT | IDLE),
     IR_SELECT  -> (jtag.tms ? RESET     | IR_CAPTURE),
     IR_CAPTURE -> (jtag.tms ? IR_EXIT1  | IR_SHIFT),

--- a/examples/src/main/scala/spinaldoc/examples/advanced/MemoryMappedUart.scala
+++ b/examples/src/main/scala/spinaldoc/examples/advanced/MemoryMappedUart.scala
@@ -14,7 +14,7 @@ object Apb3UartCtrl {
 // end object Apb3UartCtrl
 
 case class Apb3UartCtrl(uartCtrlConfig: UartCtrlGenerics, rxFifoDepth: Int) extends Component {
-  val io = new Bundle{
+  val io = new Bundle {
     val bus =  slave(Apb3(Apb3UartCtrl.getApb3Config))
     val uart = master(Uart())
   }

--- a/examples/src/main/scala/spinaldoc/examples/advanced/Slots.scala
+++ b/examples/src/main/scala/spinaldoc/examples/advanced/Slots.scala
@@ -5,39 +5,39 @@ import spinal.lib._
 import scala.language.postfixOps
 
 case class SlotsDemo(slotsCount : Int) extends Component {
-  //...
+  // ...
   
   
-  //Create the hardware for each slot
-  //Note each slot is an Area, not a Bundle
-  val slots = for(i <- 0 until slotsCount) yield new Area{
-    //Because the slot is an Area, we can define mix signal, registers, logic definitions
-    //Here are the registers for each slots
+  // Create the hardware for each slot
+  // Note each slot is an Area, not a Bundle
+  val slots = for(i <- 0 until slotsCount) yield new Area {
+    // Because the slot is an Area, we can define mix signal, registers, logic definitions
+    // Here are the registers for each slots
     val valid = RegInit(False)
     val address = Reg(UInt(8 bits))
-    val age = Reg(UInt(16 bits)) //Will count since how many cycles the slot is valid
+    val age = Reg(UInt(16 bits)) // Will count since how many cycles the slot is valid
 
-    //Here is some hardware behaviour for each slots
-    //Implement the age logic
-    when(valid){
+    // Here is some hardware behavior for each slots
+    // Implement the age logic
+    when(valid) {
       age := age + 1
     }
 
-    //removeIt will be used as a slot interface later on
+    // removeIt will be used as a slot interface later on
     val removeIt = False
-    when(removeIt){
+    when(removeIt) {
       valid := False
     }
   }
 
-  //Logic to allocate a new slot
-  val insert = new Area{
-    val cmd = Stream(UInt(8 bits)) //interface to issue requests
+  // Logic to allocate a new slot
+  val insert = new Area {
+    val cmd = Stream(UInt(8 bits)) // interface to issue requests
     val free = slots.map(!_.valid)
-    val freeOh = OHMasking.first(free) //Get the first free slot (on hot mask)
-    cmd.ready := free.orR //Only allow cmd when there is a free slot
-    when(cmd.fire){
-      //slots.onMask(freeOh)(code) will execute the code for each slot where the corresponding freeOh bit is set
+    val freeOh = OHMasking.first(free) // Get the first free slot (on hot mask)
+    cmd.ready := free.orR // Only allow cmd when there is a free slot
+    when(cmd.fire) {
+      // slots.onMask(freeOh)(code) will execute the code for each slot where the corresponding freeOh bit is set
       slots.onMask(freeOh){slot =>
         slot.valid := True
         slot.address := cmd.payload
@@ -46,21 +46,21 @@ case class SlotsDemo(slotsCount : Int) extends Component {
     }
   }
 
-  //Logic to remove the slots which match a given address (assuming there is not more than one match)
-  val remove = new Area{
-    val cmd = Flow(UInt(8 bits))//interface to issue requests
-    val oh = slots.map(s => s.valid && s.address === cmd.payload) //oh meaning "one hot"
-    when(cmd.fire){
+  // Logic to remove the slots which match a given address (assuming there is not more than one match)
+  val remove = new Area {
+    val cmd = Flow(UInt(8 bits)) // interface to issue requests
+    val oh = slots.map(s => s.valid && s.address === cmd.payload) // oh meaning "one hot"
+    when(cmd.fire) {
       slots.onMask(oh){ slot =>
         slot.removeIt := True
       }
     }
 
-    val reader = slots.reader(oh) //Create a facility to read the slots using "oh" as index
-    val age = reader(_.age) //Age of the slot which is selected by "oh"
+    val reader = slots.reader(oh) // Create a facility to read the slots using "oh" as index
+    val age = reader(_.age) // Age of the slot which is selected by "oh"
   }
   
-  //...
+  // ...
 }
 
 object SlotsDemo extends App {

--- a/examples/src/main/scala/spinaldoc/examples/advanced/Timer.scala
+++ b/examples/src/main/scala/spinaldoc/examples/advanced/Timer.scala
@@ -63,7 +63,7 @@ case class ApbTimer() extends Component {
     }
   }
 
-  //Prescaler is very similar to the timer, it mainly integrates a piece of auto reload logic.
+  // Prescaler is very similar to the timer, it mainly integrates a piece of auto reload logic.
   val prescaler = Prescaler(width = 16)
 
   val timerA = Timer(width = 32)

--- a/examples/src/main/scala/spinaldoc/examples/intermediate/Fractal.scala
+++ b/examples/src/main/scala/spinaldoc/examples/intermediate/Fractal.scala
@@ -28,32 +28,32 @@ case class PixelResult(g: PixelSolverGenerics) extends Bundle {
 // end bundles
 
 case class PixelSolver(g: PixelSolverGenerics) extends Component {
-  val io = new Bundle{
+  val io = new Bundle {
     val cmd = slave  Stream(PixelTask(g))
     val rsp = master Stream(PixelResult(g))
   }
 
   import g._
 
-  //Define states
+  // Define states
   val x, y = Reg(fixType) init(0)
   val iteration = Reg(iterationType) init(0)
 
-  //Do some shared calculation
+  // Do some shared calculation
   val xx = x*x
   val yy = y*y
   val xy = x*y
 
-  //Apply default assignment
+  // Apply default assignment
   io.cmd.ready := False
   io.rsp.valid := False
   io.rsp.iteration := iteration
 
   when(io.cmd.valid) {
-    //Is the mandelbrot iteration done ?
+    // Is the mandelbrot iteration done ?
     when(xx + yy >= 4.0 || iteration === iterationLimit) {
       io.rsp.valid := True
-      when(io.rsp.ready){
+      when(io.rsp.ready) {
         io.cmd.ready := True
         x := 0
         y := 0

--- a/examples/src/main/scala/spinaldoc/examples/intermediate/Uart.scala
+++ b/examples/src/main/scala/spinaldoc/examples/intermediate/Uart.scala
@@ -41,14 +41,14 @@ object UartStopType extends SpinalEnum(binarySequential) {
 
 // begin internal bundles
 case class UartCtrlFrameConfig(g: UartCtrlGenerics) extends Bundle {
-  val dataLength = UInt(log2Up(g.dataWidthMax) bits) //Bit count = dataLength + 1
+  val dataLength = UInt(log2Up(g.dataWidthMax) bits) // Bit count = dataLength + 1
   val stop       = UartStopType()
   val parity     = UartParityType()
 }
 
 case class UartCtrlConfig(g: UartCtrlGenerics) extends Bundle {
   val frame        = UartCtrlFrameConfig(g)
-  val clockDivider = UInt(g.clockDividerWidth bits) //see UartCtrlGenerics.clockDividerWidth for calculation
+  val clockDivider = UInt(g.clockDividerWidth bits) // see UartCtrlGenerics.clockDividerWidth for calculation
 
   def setClockDivider(baudrate: Double, clkFrequency: HertzNumber = ClockDomain.current.frequency.getValue): Unit = {
     clockDivider := (clkFrequency.toDouble / baudrate / g.rxSamplePerBit).toInt
@@ -105,8 +105,8 @@ class UartCtrlTx(g : UartCtrlGenerics) extends Component {
 
     io.write.ready := False
     switch(state) {
-      is(IDLE){
-        when(io.write.valid && clockDivider.tick){
+      is(IDLE) {
+        when(io.write.valid && clockDivider.tick) {
           state := START
         }
       }
@@ -206,7 +206,7 @@ class UartCtrlRx(g : UartCtrlGenerics) extends Component {
     val parity  = Reg(Bool())
     val shifter = Reg(io.read.payload)
 
-    //Parity calculation
+    // Parity calculation
     when(bitTimer.tick) {
       parity := parity ^ sampler.value
     }
@@ -279,7 +279,7 @@ class UartCtrl(g: UartCtrlGenerics=UartCtrlGenerics()) extends Component {
   val tx = new UartCtrlTx(g)
   val rx = new UartCtrlRx(g)
 
-  //Clock divider used by RX and TX
+  // Clock divider used by RX and TX
   val clockDivider = new Area {
     val counter = Reg(UInt(g.clockDividerWidth bits)) init 0
     val tick = counter === 0
@@ -397,8 +397,8 @@ case class UartRx() extends Component {
   io.read <> uartCtrl.io.read
 }
 
-case class UartCtrlUsageExample() extends Component{
-  val io = new Bundle{
+case class UartCtrlUsageExample() extends Component {
+  val io = new Bundle {
     val uart = master(Uart())
     val switches = in Bits(8 bits)
     val leds = out Bits(8 bits)
@@ -407,15 +407,15 @@ case class UartCtrlUsageExample() extends Component{
   val uartCtrl = new UartCtrl()
   // set config manually to show that this is still OK
   uartCtrl.io.config.setClockDivider(921600)
-  uartCtrl.io.config.frame.dataLength := 7  //8 bits
+  uartCtrl.io.config.frame.dataLength := 7  // 8 bits
   uartCtrl.io.config.frame.parity := UartParityType.NONE
   uartCtrl.io.config.frame.stop := UartStopType.ONE
   uartCtrl.io.uart <> io.uart
 
-  //Assign io.led with a register loaded each time a byte is received
+  // Assign io.led with a register loaded each time a byte is received
   io.leds := uartCtrl.io.read.toReg()
 
-  //Write the value of switch on the uart each 2000 cycles
+  // Write the value of switch on the uart each 2000 cycles
   val write = Stream(Bits(8 bits))
   write.valid := CounterFreeRun(2000).willOverflow
   write.payload := io.switches
@@ -431,7 +431,7 @@ object UartCtrlUsageExample extends App {
 
 case class UartQueued() extends Component {
   val g = UartCtrlGenerics()
-  val io = new Bundle{
+  val io = new Bundle {
     val uart = master(Uart())
     val uartConfig = in(UartCtrlConfig(g))
     val rx = master(Stream(Bits(8 bit)))
@@ -458,7 +458,7 @@ case class UartQueued() extends Component {
 }
 
 case class UartWithHeader() extends Component {
-  val io = new Bundle{
+  val io = new Bundle {
     val uart = master(Uart())
     val switches = in Bits(8 bits)
     val leds = out Bits(8 bits)
@@ -474,7 +474,7 @@ case class UartWithHeader() extends Component {
   )
   io.uart <> uartCtrl.io.uart
 
-  //Assign io.led with a register loaded each time a byte is received
+  // Assign io.led with a register loaded each time a byte is received
   io.leds := uartCtrl.io.read.toReg()
 
   // start with header

--- a/examples/src/main/scala/spinaldoc/examples/intermediate/VGA.scala
+++ b/examples/src/main/scala/spinaldoc/examples/intermediate/VGA.scala
@@ -111,19 +111,19 @@ case class VgaCtrl(rgbConfig: RgbConfig, timingsWidth: Int = 12) extends Compone
   io.vga.colorEn := colorEn
   io.vga.color := io.pixels.payload
   // end VgaCtrl connections
-  def feedWith(that : Stream[Fragment[Rgb]]): Unit ={
+  def feedWith(that : Stream[Fragment[Rgb]]): Unit = {
     io.pixels << that.toStreamOfFragment
 
     val error = RegInit(False)
-    when(io.error){
+    when(io.error) {
       error := True
     }
-    when(that.isLast){
+    when(that.isLast) {
       error := False
     }
 
     io.softReset := error
-    when(error){
+    when(error) {
       that.ready := True
     }
   }

--- a/examples/src/main/scala/spinaldoc/examples/simple/CarryAdder.scala
+++ b/examples/src/main/scala/spinaldoc/examples/simple/CarryAdder.scala
@@ -4,22 +4,22 @@ import spinal.core._
 
 import scala.language.postfixOps
 
-case class CarryAdder(size : Int) extends Component{
+case class CarryAdder(size : Int) extends Component {
   val io = new Bundle {
     val a = in UInt(size bits)
     val b = in UInt(size bits)
-    val result = out UInt(size bits)      //result = a + b
+    val result = out UInt(size bits)  // result = a + b
   }
 
-  var c = False                   //Carry, like a VHDL variable
+  var c = False   // Carry, like a VHDL variable
   for (i <- 0 until size) {
-    //Create some intermediate value in the loop scope.
+    // Create some intermediate value in the loop scope.
     val a = io.a(i)
     val b = io.b(i)
 
-    //The carry adder's asynchronous logic
+    // The carry adder's asynchronous logic
     io.result(i) := a ^ b ^ c
-    c \= (a & b) | (a & c) | (b & c);    //variable assignment
+    c \= (a & b) | (a & c) | (b & c); // variable assignment
   }
 }
 

--- a/examples/src/main/scala/spinaldoc/examples/simple/PLL.scala
+++ b/examples/src/main/scala/spinaldoc/examples/simple/PLL.scala
@@ -28,13 +28,13 @@ case class TopLevel() extends Component {
     val pll = new PLL
     pll.io.clkIn := io.clk100Mhz
 
-    //Create a new clock domain named 'core'
+    // Create a new clock domain named 'core'
     val coreClockDomain = ClockDomain.internal(
       name = "core",
       frequency = FixedFrequency(200 MHz)  // This frequency specification can be used
     )                                      // by coreClockDomain users to do some calculations
 
-    //Drive clock and reset signals of the coreClockDomain previously created
+    // Drive clock and reset signals of the coreClockDomain previously created
     coreClockDomain.clock := pll.io.clkOut
     coreClockDomain.reset := ResetCtrl.asyncAssertSyncDeassert(
       input = io.aReset || ! pll.io.isLocked,
@@ -42,9 +42,9 @@ case class TopLevel() extends Component {
     )
   }
 
-  //Create a ClockingArea which will be under the effect of the clkCtrl.coreClockDomain
+  // Create a ClockingArea which will be under the effect of the clkCtrl.coreClockDomain
   val core = new ClockingArea(clkCtrl.coreClockDomain) {
-    //Do your stuff which use coreClockDomain here
+    // Do your stuff which use coreClockDomain here
     val counter = Reg(UInt(4 bits)) init 0
     counter := counter + 1
     io.result := counter

--- a/examples/src/main/scala/spinaldoc/examples/simple/RgbToGray.scala
+++ b/examples/src/main/scala/spinaldoc/examples/simple/RgbToGray.scala
@@ -6,7 +6,7 @@ import spinal.lib.CounterFreeRun
 import scala.language.postfixOps
 
 case class RgbToGray() extends Component {
-  val io = new Bundle{
+  val io = new Bundle {
     val clear = in Bool()
     val r,g,b = in UInt(8 bits)
 
@@ -28,7 +28,7 @@ case class RgbToGray() extends Component {
   io.wr := True
   io.data := gray
 
-  when(io.clear){
+  when(io.clear) {
     gray := 0
     address.clear()
     io.wr := False

--- a/examples/src/main/scala/spinaldoc/libraries/sim/DualSimExample.scala
+++ b/examples/src/main/scala/spinaldoc/libraries/sim/DualSimExample.scala
@@ -4,7 +4,7 @@ import spinal.core._
 import spinal.core.sim._
 import spinal.lib.misc.test.DualSimTracer
 
-class Toplevel extends Component{
+class Toplevel extends Component {
   val counter = out(Reg(UInt(16 bits))) init(0)
   counter := counter + 1
 }
@@ -14,15 +14,15 @@ object Example extends App {
 
   DualSimTracer(compiled, window = 10000, seed = 42){dut=>
     dut.clockDomain.forkStimulus(10)
-    dut.clockDomain.onSamplings{
+    dut.clockDomain.onSamplings {
       val value = dut.counter.toInt
 
-      if(value % 0x1000 == 0){
+      if(value % 0x1000 == 0) {
         println(f"Value=0x$value%x at ${simTime()}")
       }
 
       // Throw a simulation failure after 64K cycles
-      if(value == 0xFFFF){
+      if(value == 0xFFFF) {
         simFailure()
       }
     }

--- a/source/SpinalHDL/Data types/Int.rst
+++ b/source/SpinalHDL/Data types/Int.rst
@@ -139,7 +139,7 @@ Logic
 
 .. note::
 
-   Notice the difference in behaviour between ``x >> 2`` (result 2 bit narrower than x) and ``x >> U(2)`` (keeping width)
+   Notice the difference in behavior between ``x >> 2`` (result 2 bit narrower than x) and ``x >> U(2)`` (keeping width)
    due to the Scala type of :code:`y`.
 
    In the first case "2" is an ``Int`` (which can be seen as an

--- a/source/SpinalHDL/Data types/Vec.rst
+++ b/source/SpinalHDL/Data types/Vec.rst
@@ -87,7 +87,7 @@ Comparison
 
    myBool := vec2 === vec1  // Compare all elements
    // is equivalent to:
-   //myBool := vec2(0) === vec1(0) && vec2(1) === vec1(1)
+   // myBool := vec2(0) === vec1(0) && vec2(1) === vec1(1)
 
 Type cast
 ~~~~~~~~~
@@ -147,10 +147,10 @@ Lib helper functions
      - Description
      - Return
    * - x.sCount(condition: T => Bool)
-     - Count the number of occurence matching a given condition in the Vec.
+     - Count the number of occurrence matching a given condition in the Vec.
      - UInt
    * - x.sCount(value: T)
-     - Count the number of occurence of a value in the Vec.
+     - Count the number of occurrence of a value in the Vec.
      - UInt
    * - x.sExists(condition: T => Bool)
      - Check if there is a matching condition in the Vec.

--- a/source/SpinalHDL/Data types/bool.rst
+++ b/source/SpinalHDL/Data types/bool.rst
@@ -13,7 +13,7 @@ generator code.
 
 An important concept and rule-of-thumb to understand is that the Scala
 `Boolean` type is used in places where elaboration-time HDL code-generation
-decision making is occuring in Scala code.  Like any regular program it affects
+decision making is occurring in Scala code.  Like any regular program it affects
 execution of the Scala program that is SpinalHDL at the time the program is
 being run to perform HDL code generation.
 

--- a/source/SpinalHDL/Data types/bundle.rst
+++ b/source/SpinalHDL/Data types/bundle.rst
@@ -85,7 +85,7 @@ Comparison
 
    myBool := color1 === color2  // Compare all elements of the bundle
    // is equivalent to:
-   //myBool := color1.r === color2.r && color1.g === color2.g && color1.b === color2.b
+   // myBool := color1.r === color2.r && color1.g === color2.g && color1.b === color2.b
 
 Type cast
 ~~~~~~~~~

--- a/source/SpinalHDL/Data types/index.rst
+++ b/source/SpinalHDL/Data types/index.rst
@@ -19,7 +19,7 @@ In addition to the base types, Spinal has support under development for:
 * :ref:`Floating-point <Floating>` numbers (experimental support)
 
 
-Additionaly, if you want to assign a don't care value to some hardware, for instance, to provide a default value, you can use the assignDontCare API to do so. 
+Additionally, if you want to assign a don't care value to some hardware, for instance, to provide a default value, you can use the assignDontCare API to do so. 
 
 
 .. code-block:: scala

--- a/source/SpinalHDL/Design errors/width_mismatch.rst
+++ b/source/SpinalHDL/Design errors/width_mismatch.rst
@@ -1,6 +1,6 @@
 
 Width mismatch
-===============
+==============
 
 Introduction
 ------------

--- a/source/SpinalHDL/Developers area/bus_slave_factory_impl.rst
+++ b/source/SpinalHDL/Developers area/bus_slave_factory_impl.rst
@@ -109,7 +109,7 @@ Let's describe primitives abstract function :
 
 
 
-   trait BusSlaveFactory  extends Area{
+   trait BusSlaveFactory  extends Area {
 
      def busDataWidth : Int
 
@@ -127,15 +127,15 @@ Let's describe primitives abstract function :
      def nonStopWrite( that : Data,
                        bitOffset : Int = 0) : Unit
 
-     //...
+     // ...
    }
 
 Then let's operate the magic to implement all utile based on them :
 
 .. code-block:: scala
 
-   trait BusSlaveFactory  extends Area{
-     //...
+   trait BusSlaveFactory  extends Are {
+     // ...
      def readAndWrite(that : Data,
                       address: BigInt,
                       bitOffset : Int = 0): Unit = {
@@ -164,7 +164,7 @@ Then let's operate the magic to implement all utile based on them :
                               address: BigInt,
                               bitOffset : Int = 0) : Unit = {
        that.valid := False
-       onWrite(address){
+       onWrite(address) {
          that.valid := True
        }
        nonStopWrite(that.payload,bitOffset)
@@ -194,7 +194,7 @@ Then let's operate the magic to implement all utile based on them :
        val reg = Reg(that)
        reg := reg | that
        read(reg,address,bitOffset)
-       onRead(address){
+       onRead(address) {
          reg := that
        }
      }
@@ -204,7 +204,7 @@ Then let's operate the magic to implement all utile based on them :
                                            validBitOffset : Int,
                                            payloadBitOffset : Int) : Unit = {
        that.ready := False
-       onRead(address){
+       onRead(address) {
          that.ready := True
        }
        read(that.valid  ,address,validBitOffset)
@@ -226,7 +226,7 @@ Then let's operate the magic to implement all utile based on them :
        val wordCount = (widthOf(that) - 1) / busDataWidth + 1
        for (wordId <- (0 until wordCount)) {
          write(
-           that = new DataWrapper{
+           that = new DataWrapper {
              override def getBitsWidth: Int =
                Math.min(busDataWidth, widthOf(that) - wordId * busDataWidth)
 
@@ -280,7 +280,7 @@ Then let's implement the ``BusSlaveFactoryDelayed`` itself :
 
 .. code-block:: scala
 
-   trait BusSlaveFactoryDelayed extends BusSlaveFactory{
+   trait BusSlaveFactoryDelayed extends BusSlaveFactory {
      // elements is an array of all BusSlaveFactoryElement requested
      val elements = ArrayBuffer[BusSlaveFactoryElement]()
 
@@ -320,7 +320,7 @@ Then let's implement the ``BusSlaveFactoryDelayed`` itself :
        elements += BusSlaveFactoryNonStopWrite(that,bitOffset)
      }
 
-     //This is the only thing that should be implement by class that extends BusSlaveFactoryDelayed
+     // This is the only thing that should be implement by class that extends BusSlaveFactoryDelayed
      def build() : Unit
 
      component.addPrePopTask(() => build())
@@ -360,13 +360,13 @@ First let's implement the companion object that provide the compatible AvalonMM 
 
 .. code-block:: scala
 
-   object AvalonMMSlaveFactory{
+   object AvalonMMSlaveFactory {
      def getAvalonConfig( addressWidth : Int,
                           dataWidth : Int) = {
-       AvalonMMConfig.pipelined(   //Create a simple pipelined configuration of the Avalon Bus
+       AvalonMMConfig.pipelined(   // Create a simple pipelined configuration of the Avalon Bus
          addressWidth = addressWidth,
          dataWidth = dataWidth
-       ).copy(                    //Change some parameters of the configuration
+       ).copy(                     // Change some parameters of the configuration
          useByteEnable = false,
          useWaitRequestn = false
        )
@@ -379,7 +379,7 @@ Then, let's implement the AvalonMMSlaveFactory itself.
 
 .. code-block:: scala
 
-   class AvalonMMSlaveFactory(bus : AvalonMM) extends BusSlaveFactoryDelayed{
+   class AvalonMMSlaveFactory(bus : AvalonMM) extends BusSlaveFactoryDelayed {
      assert(bus.c == AvalonMMSlaveFactory.getAvalonConfig(bus.c.addressWidth,bus.c.dataWidth))
 
      val readAtCmd = Flow(Bits(bus.c.dataWidth bits))
@@ -398,10 +398,10 @@ Then, let's implement the AvalonMMSlaveFactory itself.
          case _ =>
        }
 
-       for((address,jobs) <- elementsPerAddress){
-         when(bus.address === address){
-           when(bus.write){
-             for(element <- jobs) element match{
+       for((address,jobs) <- elementsPerAddress) {
+         when(bus.address === address) {
+           when(bus.write) {
+             for(element <- jobs) element match {
                case element : BusSlaveFactoryWrite => {
                  element.that.assignFromBits(bus.writeData(element.bitOffset, element.that.getBitsWidth bits))
                }
@@ -409,8 +409,8 @@ Then, let's implement the AvalonMMSlaveFactory itself.
                case _ =>
              }
            }
-           when(bus.read){
-             for(element <- jobs) element match{
+           when(bus.read) {
+             for(element <- jobs) element match {
                case element : BusSlaveFactoryRead => {
                  readAtCmd.payload(element.bitOffset, element.that.getBitsWidth bits) := element.that.asBits
                }

--- a/source/SpinalHDL/Developers area/spinalhdl_datamodel.rst
+++ b/source/SpinalHDL/Developers area/spinalhdl_datamodel.rst
@@ -1,18 +1,18 @@
 
 SpinalHDL internal datamodel
-===================================
+============================
 
 .. role:: raw-html-m2r(raw)
    :format: html
 
 
 Introduction
-------------------------------------------------
+------------
 
 This page provides documentation on the internal data structure utilized by SpinalHDL for storing and modifying the netlist described by users via the SpinalHDL API.
 
 General structure
-------------------------
+-----------------
 
 The following diagrams follow the UML nomenclature : 
 
@@ -41,24 +41,24 @@ Additionally, as a side note, while the *foreachXXX* functions iterate only one 
 
 There are also utilities like *myExpression.remapExpressions(Expression => Expression),* which iterate through all the expressions used within *myExpression* and replace them with the one you provide.
 
-More generaly, most of the graph checks and transformations done by SpinalHDL are located in <https://github.com/SpinalHDL/SpinalHDL/blob/dev/core/src/main/scala/spinal/core/internals/Phase.scala> 
+More generally, most of the graph checks and transformations done by SpinalHDL are located in <https://github.com/SpinalHDL/SpinalHDL/blob/dev/core/src/main/scala/spinal/core/internals/Phase.scala> 
 
 Exploring the datamodel
--------------------------------
+-----------------------
 
 Here is an example that identifies all adders within the netlist without utilizing shortcuts. : 
 
 .. code-block:: scala
 
-    object FindAllAddersManualy {
-      class Toplevel extends Component{
+    object FindAllAddersManually {
+      class Toplevel extends Component {
         val a,b,c = in UInt(8 bits)
         val result = out(a + b + c)
       }
 
       import spinal.core.internals._
 
-      class PrintBaseTypes(message : String) extends Phase{
+      class PrintBaseTypes(message : String) extends Phase {
         override def impl(pc: PhaseContext) = {
           println(message)
 
@@ -94,10 +94,10 @@ Here is an example that identifies all adders within the netlist without utilizi
       def main(args: Array[String]): Unit = {
         val config = SpinalConfig()
 
-        //Add a early phase
+        // Add a early phase
         config.addTransformationPhase(new PrintBaseTypes("Early"))
 
-        //Add a late phase
+        // Add a late phase
         config.phasesInserters += {phases =>
           phases.insert(phases.indexWhere(_.isInstanceOf[PhaseVerilog]), new PrintBaseTypes("Late"))
         }
@@ -130,7 +130,7 @@ Please note that in many cases, shortcuts are available. All the recursive proce
 
     override def impl(pc: PhaseContext) = {
       println(message)
-      pc.walkExpression{
+      pc.walkExpression {
         case op: Operator.BitVector.Add => println(s"Found ${op.left} + ${op.right}")
         case _ =>
       }
@@ -138,7 +138,7 @@ Please note that in many cases, shortcuts are available. All the recursive proce
 
 
 Compilation Phases
--------------------------------
+------------------
 
 Here is the complete list of default phases, arranged in order, that are employed to modify, check, and generate Verilog code from a top-level component. : 
 
@@ -149,12 +149,12 @@ If you, as a user, add a new compilation phase by using *SpinalConfig.addTransfo
 If you choose to use the SpinalConfig.phasesInserters API, it's essential to exercise caution and ensure that any modifications made to the netlist align with the phases that have already been executed. For instance, if you insert your phase after the *PhaseInferWidth*, you must specify the width of each node you introduce.
 
 Modifying a netlist as a user without plugins
---------------------------------------------------------------
+---------------------------------------------
 
 There are several user APIs that enable you to make modifications during the user elaboration phase. :
 
 - mySignal.removeAssignments : Will remove all previous `:=` affecting the given signal
-- mySignal.removeStatement : Will void the existance of the signal
+- mySignal.removeStatement : Will void the existence of the signal
 - mySignal.setAsDirectionLess : Will turn a in / out signal into a internal signal
 - mySignal.setName : Enforce a given name on a signal (there is many other variants)
 - mySubComponent.mySignal.pull() : Will provide a readable copy of the given signal, even if that signal is somewhere else in the hierarchy
@@ -164,18 +164,18 @@ For example, the following code can be used to modify a top-level component by a
 
 .. code-block:: scala
 
-  def ffIo[T <: Component](c : T): T ={
+  def ffIo[T <: Component](c : T): T = {
     def buf1[T <: Data](that : T) = KeepAttribute(RegNext(that)).addAttribute("DONT_TOUCH")
     def buf[T <: Data](that : T) = buf1(buf1(buf1(that)))
-    c.rework{
+    c.rework {
       val ios = c.getAllIo.toList
       ios.foreach{io =>
-        if(io.getName() == "clk"){
-          //Do nothing
-        } else if(io.isInput){
-          io.setAsDirectionLess().allowDirectionLessIo  //allowDirectionLessIo is to disable the io Bundle linting
+        if(io.getName() == "clk") {
+          // Do nothing
+        } else if(io.isInput) {
+          io.setAsDirectionLess().allowDirectionLessIo  // allowDirectionLessIo is to disable the io Bundle linting
           io := buf(in(cloneOf(io).setName(io.getName() + "_wrap")))
-        } else if(io.isOutput){
+        } else if(io.isOutput) {
           io.setAsDirectionLess().allowDirectionLessIo
           out(cloneOf(io).setName(io.getName() + "_wrap")) := buf(io)
         } else ???
@@ -211,12 +211,12 @@ Here is a function that enables you to execute the body code as if the current c
   
   object key
   
-  when(something){
-    if(somehow){
+  when(something) {
+    if(somehow) {
       get(key) := True
     }
   }  
-  when(database(key)){
+  when(database(key)) {
      ...
   }
   
@@ -251,7 +251,7 @@ In this case, this is accomplished after the elaboration process by utilizing th
 .. code-block:: scala
 
 
-    object MyTopLevelVerilog extends App{
+    object MyTopLevelVerilog extends App {
       class MyTopLevel extends Component {
         val cdA = ClockDomain.external("rawrr")
         val regA = cdA(RegNext(False))

--- a/source/SpinalHDL/Developers area/types.rst
+++ b/source/SpinalHDL/Developers area/types.rst
@@ -115,7 +115,7 @@ The following operators are available for the ``Bool`` type
 
 
 The BitVector family - (``Bits``, ``UInt``, ``SInt``)
------------------------------------------------------------------
+-----------------------------------------------------
 
 | ``BitVector`` is a family of types for storing multiple bits of information in a single value. This type has three subtypes that can be used to model different behaviours:
 | ``Bits`` do not convey any sign information whereas the ``UInt`` (unsigned integer) and ``SInt`` (signed integer) provide the required operations to compute correct results if signed / unsigned arithmetic is used.
@@ -207,11 +207,11 @@ You can define a Range values
    val myBool := myUInt === U(7 -> true,(6 downto 0) -> false)
    val myBool := myUInt === U(myUInt.range -> true)
 
-   //For assignment purposes, you can omit the B/U/S, which also alow the use of the [default -> ???] feature
-   myUInt := (default -> true)                       //Assign myUInt with "11111111"
-   myUInt := (myUInt.range -> true)                  //Assign myUInt with "11111111"
-   myUInt := (7 -> true,default -> false)            //Assign myUInt with "10000000"
-   myUInt := ((4 downto 1) -> true,default -> false) //Assign myUInt with "00011110"
+   // For assignment purposes, you can omit the B/U/S, which also alow the use of the [default -> ???] feature
+   myUInt := (default -> true)                       // Assign myUInt with "11111111"
+   myUInt := (myUInt.range -> true)                  // Assign myUInt with "11111111"
+   myUInt := (7 -> true,default -> false)            // Assign myUInt with "10000000"
+   myUInt := ((4 downto 1) -> true,default -> false) // Assign myUInt with "00011110"
 
 Operators
 ^^^^^^^^^
@@ -451,10 +451,10 @@ Vec
 
    val x,y,z = UInt(8 bits)
    val myVecOf_xyz_ref = Vec(x,y,z)
-   for(element <- myVecOf_xyz_ref){
-     element := 0   //Assign x,y,z with the value 0
+   for(element <- myVecOf_xyz_ref) {
+     element := 0   // Assign x,y,z with the value 0
    }
-   myVecOf_xyz_ref(1) := 3    //Assign y with the value 3
+   myVecOf_xyz_ref(1) := 3    // Assign y with the value 3
 
 Bundle
 ------
@@ -491,15 +491,15 @@ Then you can also incorporate a Bundle inside Bundle as deeply as you want:
      val color = RGB(channelWidth)
    }
 
-And finaly instantiate your Bundles inside the hardware :
+And finally instantiate your Bundles inside the hardware :
 
 .. code-block:: scala
 
-   val vgaIn  = VGA(8)         //Create a RGB instance
+   val vgaIn  = VGA(8)        // Create a RGB instance
    val vgaOut = VGA(8)
-   vgaOut := vgaIn            //Assign the whole bundle
-   vgaOut.color.green := 0    //Fix the green to zero
-   val vgaInRgbIsBlack = vgaIn.rgb.isBlack   //Get if the vgaIn rgb is black
+   vgaOut := vgaIn            // Assign the whole bundle
+   vgaOut.color.green := 0    // Fix the green to zero
+   val vgaInRgbIsBlack = vgaIn.rgb.isBlack   // Get if the vgaIn rgb is black
 
 If you want to specify your bundle as an input or an output of a Component, you have to do it by the following way :
 
@@ -507,7 +507,7 @@ If you want to specify your bundle as an input or an output of a Component, you 
 
    class MyComponent extends Component {
      val io = Bundle {
-       val cmd = in(RGB(8))    //Don't forget the bracket around the bundle.
+       val cmd = in(RGB(8))    // Don't forget the bracket around the bundle.
        val rsp = out(RGB(8))
      }
    }
@@ -534,7 +534,7 @@ If you want to define an interface, let's imagine an APB interface, you can also
      val PWRITE     = Bool()
      val PWDATA     = Bits(dataWidth bits)
      val PRDATA     = Bits(dataWidth bits)
-     val PSLVERROR  = if(useSlaveError) Bool() else null   //This wire is created only when useSlaveError is true
+     val PSLVERROR  = if(useSlaveError) Bool() else null   // This wire is created only when useSlaveError is true
    }
 
    // Example of usage :
@@ -554,7 +554,7 @@ Also if one time you need to add another construction parameter, you will only h
                         selWidth : Int,
                         useSlaveError : Boolean)
 
-   class APB(val config: APBConfig) extends Bundle {   //[val] config, make the configuration public
+   class APB(val config: APBConfig) extends Bundle {   // [val] config, make the configuration public
      val PADDR      = UInt(config.addressWidth bits)
      val PSEL       = Bits(config.selWidth bits)
      val PENABLE    = Bool()
@@ -598,7 +598,7 @@ Then at some points, you will probably need to use the APB bus as master or as s
        this
      }
 
-     def asSlave(): this.type = this.asMaster().flip() //Flip reverse all in out configuration.
+     def asSlave(): this.type = this.asMaster().flip() // Flip reverse all in out configuration.
    }
 
    // Example of usage
@@ -623,7 +623,7 @@ An example of an APB bus that implement this IMasterSlave :
 
 .. code-block:: scala
 
-   //You need to import spinal.lib._ to use IMasterSlave
+   // You need to import spinal.lib._ to use IMasterSlave
    import spinal.core._
    import spinal.lib._
 
@@ -640,14 +640,14 @@ An example of an APB bus that implement this IMasterSlave :
      val PWRITE     = Bool()
      val PWDATA     = Bits(dataWidth bits)
      val PRDATA     = Bits(dataWidth bits)
-     val PSLVERROR  = if(useSlaveError) Bool() else null   //This wire is created only when useSlaveError is true
+     val PSLVERROR  = if(useSlaveError) Bool() else null   // This wire is created only when useSlaveError is true
 
      override def asMaster() : Unit = {
        out(PADDR,PSEL,PENABLE,PWRITE,PWDATA)
        in(PREADY,PRDATA)
        if(useSlaveError) in(PSLVERROR)
      }
-     //The asSlave is by default the flipped version of asMaster.
+     // The asSlave is by default the flipped version of asMaster.
    }
 
 Enum
@@ -689,7 +689,7 @@ Instantiate a signal to store the enumeration encoded value and assign it a valu
    val stateNext = UartCtrlTxState() // Or UartCtrlTxState(encoding=encodingOfYouChoice)
    stateNext := UartCtrlTxState.sIdle
 
-   //You can also import the enumeration to have the visibility on its elements
+   // You can also import the enumeration to have the visibility on its elements
    import UartCtrlTxState._
    stateNext := sIdle
 
@@ -758,8 +758,8 @@ An example :
    val cond = in Bool()
    val red = in UInt(4 bits)
    ...
-   val valid = False          //Bool wire which is by default assigned with False
-   val value = U"0100"        //UInt wire of 4 bits which is by default assigned with 4
+   val valid = False          // Bool wire which is by default assigned with False
+   val value = U"0100"        // UInt wire of 4 bits which is by default assigned with 4
    when(cond) {
      valid := True
      value := red

--- a/source/SpinalHDL/Examples/Advanced ones/jtag.rst
+++ b/source/SpinalHDL/Examples/Advanced ones/jtag.rst
@@ -95,7 +95,7 @@ Then let the ``JtagTap`` implement this abstract interface:
    :caption: Additions to ``class JtagTap``
    :start-at: override def getTdi
    :end-before: // end class JtagTap
-   :prepend: class JtagTap(val jtag: Jtag, ...) extends Area with JtagTapAccess{
+   :prepend: class JtagTap(val jtag: Jtag, ...) extends Area with JtagTapAccess {
              ...
 
 Base class

--- a/source/SpinalHDL/Examples/Advanced ones/slots.rst
+++ b/source/SpinalHDL/Examples/Advanced ones/slots.rst
@@ -14,7 +14,7 @@ Implementation
 
 This implementation avoid the use of Vec. Instead, it use Area which allow to mix signal, registers and logic definitions in each slot.
 
-Note that the `reader` API is for SpinalHDL version comming after 1.9.1
+Note that the `reader` API is for SpinalHDL version coming after 1.9.1
 
 .. literalinclude:: /../examples/src/main/scala/spinaldoc/examples/advanced/Slots.scala
    :language: scala
@@ -27,7 +27,7 @@ For instance, this kind of slot pattern is used in Tilelink coherency hub to kee
 
 https://github.com/SpinalHDL/SpinalHDL/blob/008c73f1ce18e294f137efe7a1442bd3f8fa2ee0/lib/src/main/scala/spinal/lib/bus/tilelink/coherent/Hub.scala#L376   
 
-As well in the DRAM / SDR / DDR memory controller to implement the handeling of multiple memory transactions at once (having multiple precharge / active / read / write running at the same time to improve performances) : 
+As well in the DRAM / SDR / DDR memory controller to implement the handling of multiple memory transactions at once (having multiple precharge / active / read / write running at the same time to improve performances) : 
 
 https://github.com/SpinalHDL/SpinalHDL/blob/1edba1890b5f629b28e5171b3c449155337d2548/lib/src/main/scala/spinal/lib/memory/sdram/xdr/Tasker.scala#L202
 

--- a/source/SpinalHDL/Examples/Advanced ones/timer.rst
+++ b/source/SpinalHDL/Examples/Advanced ones/timer.rst
@@ -123,13 +123,13 @@ The register mapping assumes that the bus system is 32 bits wide:
      - len(ticks)
      - 0
      - 0
-     - Each ``ticks`` bool can be actived if the corresponding ``ticksEnable`` bit is high.
+     - Each ``ticks`` bool can be activated if the corresponding ``ticksEnable`` bit is high.
    * - clearsEnable
      - RW
      - len(clears)
      - 0
      - 16
-     - Each ``clears`` bool can be actived if the corresponding ``clearsEnable`` bit is high.
+     - Each ``clears`` bool can be activated if the corresponding ``clearsEnable`` bit is high.
    * - limit
      - RW
      - width

--- a/source/SpinalHDL/Examples/Intermediates ones/vga.rst
+++ b/source/SpinalHDL/Examples/Intermediates ones/vga.rst
@@ -145,9 +145,9 @@ Let's define a new VgaCtrl ``Component``\ , which takes as ``RgbConfig`` and ``t
 Horizontal and vertical logic
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The logic that generates horizontal and vertical synchronization signals is quite the same. It kind of resembles ~PWM~. The horizontal one counts up each cycle, while the vertical one use the horizontal syncronization signal as to increment.
+The logic that generates horizontal and vertical synchronization signals is quite the same. It kind of resembles ~PWM~. The horizontal one counts up each cycle, while the vertical one use the horizontal synchronization signal as to increment.
 
-Let's define ``HVArea``\ , which represents one ~PWM~ and then instantiate it two times: one for both horizontal and vertical syncronization.
+Let's define ``HVArea``\ , which represents one ~PWM~ and then instantiate it two times: one for both horizontal and vertical synchronization.
 
 .. literalinclude:: /../examples/src/main/scala/spinaldoc/examples/intermediate/VGA.scala
    :language: scala

--- a/source/SpinalHDL/Examples/index.rst
+++ b/source/SpinalHDL/Examples/index.rst
@@ -45,6 +45,6 @@ To generate VHDL for a given component, you can place the following at the botto
 
    object MyMainObject {
      def main(args: Array[String]) {
-       SpinalVhdl(new TheComponentThatIWantToGenerate(constructionArguments))   //Or SpinalVerilog
+       SpinalVhdl(new TheComponentThatIWantToGenerate(constructionArguments))   // Or SpinalVerilog
      }
    }

--- a/source/SpinalHDL/Foreword/index.rst
+++ b/source/SpinalHDL/Foreword/index.rst
@@ -10,7 +10,7 @@ Preliminary notes:
 * For conciseness, let's assume that SystemVerilog is a recent revision of
   Verilog.
 * When reading this, we should not underestimate how much our attachment for our
-  favourite HDL will bias our judgement.
+  favorite HDL will bias our judgement.
 
 
 Why moving away from traditional HDL
@@ -187,7 +187,7 @@ peripherals instantiation and adding the APB3 decoder required to access them.
    val vgaCtrl = Axi4VgaCtrl(vgaCtrlConfig)
 
    // Instantiate an APB3 decoder
-   // - Drived by the apbBridge
+   // - Driven by the apbBridge
    // - Map each peripheral in a memory region
    val apbDecoder = Apb3Decoder(
      master = apbBridge.io.apb,
@@ -262,7 +262,7 @@ on the top of SpinalHDL:
 .. code-block:: scala
 
    // Define a new state machine
-   val fsm = new StateMachine{
+   val fsm = new StateMachine {
      // Define all states
      val stateA, stateB, stateC = new State
 
@@ -272,14 +272,14 @@ on the top of SpinalHDL:
      // Define a register used into the state machine
      val counter = Reg(UInt(8 bits)) init (0)
 
-     // Define the state machine behaviour for each state
+     // Define the state machine behavior for each state
      stateA.whenIsActive (goto(stateB))
 
      stateB.onEntry(counter := 0)
      stateB.onExit(io.result := True)
      stateB.whenIsActive {
        counter := counter + 1
-       when(counter === 4){
+       when(counter === 4) {
          goto(stateC)
        }
      }

--- a/source/SpinalHDL/Formal verification/index.rst
+++ b/source/SpinalHDL/Formal verification/index.rst
@@ -1,6 +1,6 @@
-=======================
+===================
 Formal verification
-=======================
+===================
 
 
 General
@@ -58,9 +58,9 @@ Here is an example of a simple counter and the corresponding formal testbench.
 
     import spinal.core._
     
-    //Here is our DUT
+    // Here is our DUT
     class LimitedCounter extends Component {
-      //The value register will always be between [2:10]
+      // The value register will always be between [2:10]
       val value = Reg(UInt(4 bits)) init(2)
       when(value < 10) {
         value := value + 1
@@ -125,7 +125,7 @@ but you can also use the formal `anyseq`, `anyconst`, `allseq`, `allconst` state
 .. code-block:: scala
 
     class LimitedCounterInc extends Component {
-      //Only increment the value when the inc input is set
+      // Only increment the value when the inc input is set
       val inc = in Bool()
       val value = Reg(UInt(4 bits)) init(2)
       when(inc && value < 10) {
@@ -192,7 +192,7 @@ Here is an example where we want to prevent the value ``1`` from ever being pres
 
         // Allow the write anything but value 1 in the ram
         anyseq(dut.write)
-        clockDomain.withoutReset() { //As the memory write can occur during reset, we need to ensure the assume apply there too
+        clockDomain.withoutReset() { // As the memory write can occur during reset, we need to ensure the assume apply there too
           assume(dut.write.data =/= 1)
         }
 
@@ -223,7 +223,7 @@ If you want to keep your assertion enabled during reset you can do:
 Specifying the initial value of a signal 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For instance, for the reset signal of the current clockdomain (usefull at the top)
+For instance, for the reset signal of the current clockdomain (useful at the top)
 
 .. code-block:: scala
 
@@ -245,12 +245,12 @@ If you have a Mem in your design, and you want to check its content, you can do 
 
     // Manual access
     for(i <- 0 until dut.ram.wordCount) {
-      assumeInitial(dut.ram(i) =/= X) //No occurence of the word X
+      assumeInitial(dut.ram(i) =/= X) // No occurrence of the word X
     }
     
-    assumeInitial(!dut.ram.formalContains(X)) //No occurence of the word X
+    assumeInitial(!dut.ram.formalContains(X)) // No occurrence of the word X
     
-    assumeInitial(dut.ram.formalCount(X) === 1) //only one occurence of the word X
+    assumeInitial(dut.ram.formalCount(X) === 1) // only one occurrence of the word X
     
 
 Specifying assertion in the reset scope
@@ -306,7 +306,7 @@ Formal primitives
       - Returns True when the past value is valid (False on the first cycle). Recommended to be used with each application of ``past``, ``rose``, ``fell``, ``changed`` and ``stable``.
     * - ``pastValidAfterReset()``
       - Bool
-      - Simliar to ``pastValid``, where only difference is that this would take reset into account. Can be understood as ``pastValid & past(!reset)``.
+      - Similar to ``pastValid``, where only difference is that this would take reset into account. Can be understood as ``pastValid & past(!reset)``.
 
 Note that you can use the init statement on past: 
 
@@ -335,4 +335,4 @@ The minimum required assertions internally in a ``Component`` for "prove" can be
 For interfaces implement IMasterSlave
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 There could be functions in name ``formalAssertsMaster``, ``formalAssertsSlave``, ``formalAssumesMaster``, ``formalAssumesSlave`` or ``formalCovers``.
-Master/Slave are target interface type, so that ``formalAssertsMaster`` can be understand as "formal verfication assertions for master interface".
+Master/Slave are target interface type, so that ``formalAssertsMaster`` can be understand as "formal verification assertions for master interface".

--- a/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_perspective.rst
+++ b/source/SpinalHDL/Getting Started/Help for VHDL people/vhdl_perspective.rst
@@ -14,7 +14,7 @@ Here is an example of a component which has 3 inputs (``a``, ``b``, ``c``) and a
 .. code-block:: scala
 
    case class MyComponent(offset: Int) extends Component {
-     val io = new Bundle{
+     val io = new Bundle {
        val a, b, c = in UInt(8 bits)
        val result  = out UInt(8 bits)
      }

--- a/source/SpinalHDL/Getting Started/Install and setup.rst
+++ b/source/SpinalHDL/Getting Started/Install and setup.rst
@@ -80,7 +80,7 @@ download link for the latest version. You can download/extract oss-cad-suite to 
    curl -fLO <download link>
    tar xzf <file that you downloaded>
 
-To use oss-cad-suite in a shell you need to load it's environment, e.g. via ``souce <path to oss-cad-suite>/environment``.
+To use oss-cad-suite in a shell you need to load it's environment, e.g. via ``source <path to oss-cad-suite>/environment``.
 
 
 Mac OS X Installation

--- a/source/SpinalHDL/Getting Started/Scala Guide/basics.rst
+++ b/source/SpinalHDL/Getting Started/Scala Guide/basics.rst
@@ -50,7 +50,7 @@ Scala is able to infer the type automatically. You don't need to specify it if t
 
 .. code-block:: scala
 
-   var number = 0   //The type of 'number' is inferred as an Int during compilation.
+   var number = 0   // The type of 'number' is inferred as an Int during compilation.
 
 However, it's not very common to use ``var`` in Scala. Instead, constant values defined by ``val`` are often used:
 
@@ -152,7 +152,7 @@ Functions named ``apply`` are special because you can call them without having t
    }
 
    val array = new Array()
-   val value = array(4)   //array(4) is interpreted as array.apply(4) and will return 7
+   val value = array(4)   // array(4) is interpreted as array.apply(4) and will return 7
 
 This concept is also applicable for Scala ``object`` (static)
 

--- a/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
+++ b/source/SpinalHDL/Introduction/Projects using SpinalHDL.rst
@@ -1,7 +1,7 @@
 Projects using SpinalHDL
 ------------------------
 
-Note that the following lists are very incompletes.
+Note that the following lists are very incomplete.
 
 .. _users_repositories:
 

--- a/source/SpinalHDL/Legacy/pinsec/hardware.rst
+++ b/source/SpinalHDL/Legacy/pinsec/hardware.rst
@@ -75,7 +75,7 @@ Or you can create your own main into your own SBT project and then run it :
 
    import spinal.lib.soc.pinsec._
 
-   object PinsecMain{
+   object PinsecMain {
      def main(args: Array[String]) {
        SpinalVhdl(new Pinsec(100 MHz))
        SpinalVerilog(new Pinsec(100 MHz))

--- a/source/SpinalHDL/Legacy/pinsec/introduction.rst
+++ b/source/SpinalHDL/Legacy/pinsec/introduction.rst
@@ -9,7 +9,7 @@ Introduction
 .. note::
    This page only documents the SoC implemented with the first generation of RISC-V CPU created in SpinalHDL.
    This page does not document the VexRiscV CPU, which is the second generation of this SoC (and CPU) is available
-   `here <https://github.com/SpinalHDL/VexRiscv>`__ and offers better perforance/area/features.
+   `here <https://github.com/SpinalHDL/VexRiscv>`__ and offers better performance/area/features.
 
 Introduction
 ------------

--- a/source/SpinalHDL/Legacy/riscv.rst
+++ b/source/SpinalHDL/Legacy/riscv.rst
@@ -77,6 +77,6 @@ Todo
 
 
 * Documentation
-* Optimise instruction/data caches FMax by moving line hit condition forward into combinatorial paths.
+* Optimize instruction/data caches FMax by moving line hit condition forward into combinatorial paths.
 
 Contact spinalhdl@gmail.com for more information

--- a/source/SpinalHDL/Libraries/Bus/amba3/ahblite3.rst
+++ b/source/SpinalHDL/Libraries/Bus/amba3/ahblite3.rst
@@ -2,7 +2,7 @@
 AHB-Lite3
 =========
 
-Configuration and instanciation
+Configuration and instantiation
 -------------------------------
 
 First each time you want to create a AHB-Lite3 bus, you will need a configuration object. This configuration object is an ``AhbLite3Config`` and has following arguments :
@@ -29,7 +29,7 @@ There is in short how the AHB-Lite3 bus is defined in the SpinalHDL library :
 
 .. code-block:: scala
 
-   case class AhbLite3(config: AhbLite3Config) extends Bundle with IMasterSlave{
+   case class AhbLite3(config: AhbLite3Config) extends Bundle with IMasterSlave {
      //  Address and control
      val HADDR = UInt(config.addressWidth bits)
      val HSEL = Bool()
@@ -66,8 +66,8 @@ There is a short example of usage :
    val ahbX = AhbLite3(ahbConfig)
    val ahbY = AhbLite3(ahbConfig)
 
-   when(ahbY.HSEL){
-     //...
+   when(ahbY.HSEL) {
+     // ...
    }
 
 Variations

--- a/source/SpinalHDL/Libraries/Bus/amba3/apb3.rst
+++ b/source/SpinalHDL/Libraries/Bus/amba3/apb3.rst
@@ -4,7 +4,7 @@ Apb3
 
 The AMBA3-APB bus is commonly used to interface low bandwidth peripherals.
 
-Configuration and instanciation
+Configuration and instantiation
 -------------------------------
 
 First each time you want to create a APB3 bus, you will need a configuration object. This configuration object is an ``Apb3Config`` and has following arguments :
@@ -48,7 +48,7 @@ There is in short how the APB3 bus is defined in the SpinalHDL library :
      val PWDATA     = Bits(config.dataWidth bits)
      val PRDATA     = Bits(config.dataWidth bits)
      val PSLVERROR  = if(config.useSlaveError) Bool() else null
-     //...
+     // ...
    }
 
 There is a short example of usage :
@@ -62,8 +62,8 @@ There is a short example of usage :
    val apbX = Apb3(apbConfig)
    val apbY = Apb3(apbConfig)
 
-   when(apbY.PENABLE){
-     //...
+   when(apbY.PENABLE) {
+     // ...
    }
 
 Functions and operators

--- a/source/SpinalHDL/Libraries/Bus/amba4/axi4.rst
+++ b/source/SpinalHDL/Libraries/Bus/amba4/axi4.rst
@@ -3,7 +3,7 @@ Axi4
 
 The AXI4 is a high bandwidth bus defined by ARM.
 
-Configuration and instanciation
+Configuration and instantiation
 -------------------------------
 
 First each time you want to create a AXI4 bus, you will need a configuration object. This configuration object is an ``Axi4Config`` and has following arguments :
@@ -73,7 +73,7 @@ There is in short how the AXI4 bus is defined in the SpinalHDL library :
 
 .. code-block:: scala
 
-   case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave{
+   case class Axi4(config: Axi4Config) extends Bundle with IMasterSlave {
      val aw = Stream(Axi4Aw(config))
      val w  = Stream(Axi4W(config))
      val b  = Stream(Axi4B(config))
@@ -98,8 +98,8 @@ There is a short example of usage :
    val axiX = Axi4(axiConfig)
    val axiY = Axi4(axiConfig)
 
-   when(axiY.aw.valid){
-     //...
+   when(axiY.aw.valid) {
+     // ...
    }
 
 Variations

--- a/source/SpinalHDL/Libraries/Bus/avalon/avalonmm.rst
+++ b/source/SpinalHDL/Libraries/Bus/avalon/avalonmm.rst
@@ -8,7 +8,7 @@ The AvalonMM bus fit very well in FPGA. It is very flexible :
 * Better for than AHB in many application that need bandwidth because AvalonMM has a mode that decouple read response from commands (reduce latency read latency impact).
 * Less performance than AXI but use much less area (Read and write command use the same handshake channel. The master don't need to store address of pending request to avoid Read/Write hazard)
 
-Configuration and instanciation
+Configuration and instantiation
 -------------------------------
 
 The ``AvalonMM`` Bundle has a construction argument ``AvalonMMConfig``. Because of the flexible nature of the Avalon bus, the ``AvalonMMConfig`` as many configuration elements. For more information the Avalon spec could be find on the intel website.
@@ -27,7 +27,7 @@ The ``AvalonMM`` Bundle has a construction argument ``AvalonMMConfig``. Because 
                               useWaitRequestn : Boolean,
                               useReadDataValid : Boolean,
                               useBurstCount : Boolean,
-                              //useEndOfPacket : Boolean,
+                              // useEndOfPacket : Boolean,
 
                               addressUnits : AddressUnits = symbols,
                               burstCountUnits : AddressUnits = words,

--- a/source/SpinalHDL/Libraries/Bus/tilelink/tilelink.rst
+++ b/source/SpinalHDL/Libraries/Bus/tilelink/tilelink.rst
@@ -1,8 +1,8 @@
 
 Tilelink
-=========
+========
 
-Configuration and instanciation
+Configuration and instantiation
 -------------------------------
 
 There is a short example to define two non coherent tilelink bus instance and connect them:
@@ -40,7 +40,7 @@ Here is the same as above, but with coherency channels
     val busA, busB = tilelink.Bus(param)
     busA << busB
 
-Those above where for the hardware instanciation, the thing is that it is the simple / easy part. When things goes into SoC / memory coherency, you kind of need an additional layer to negociate / propagate parameters all around. 
+Those above where for the hardware instantiation, the thing is that it is the simple / easy part. When things goes into SoC / memory coherency, you kind of need an additional layer to negotiate / propagate parameters all around. 
 That's what tilelink.fabric.Node is about.
 
 

--- a/source/SpinalHDL/Libraries/Bus/tilelink/tilelink_fabric.rst
+++ b/source/SpinalHDL/Libraries/Bus/tilelink/tilelink_fabric.rst
@@ -1,10 +1,10 @@
 
 tilelink.fabric.Node
-===========================
+====================
 
-tilelink.fabric.Node is an additional layer over the regular tilelink hardware instanciation which handle negociation and parameters propagation at a SoC level.
+tilelink.fabric.Node is an additional layer over the regular tilelink hardware instantiation which handle negotiation and parameters propagation at a SoC level.
 
-It is mostly based on the Fiber API, which allows to create elaboration time fibers (user-space threads), allowing to schedule future parameter propagation / negociation and hardware elaboration.
+It is mostly based on the Fiber API, which allows to create elaboration time fibers (user-space threads), allowing to schedule future parameter propagation / negotiation and hardware elaboration.
 
 A Node can be created in 3 ways : 
 
@@ -21,7 +21,7 @@ Nodes mostly have the following attributes :
 
 You can note that they all are Handles. Handle is a way in SpinalHDL to have share a value between fibers. If a fiber read a Handle while this one has no value yet, it will block the execution of that fiber until another fiber provide a value to the Handle.
 
-There is also a set of attribues like m2s, but reversed (named s2m) which specify the parameters for the transactions initiated by the slave side of the interconnect (ex memory coherency).
+There is also a set of attributes like m2s, but reversed (named s2m) which specify the parameters for the transactions initiated by the slave side of the interconnect (ex memory coherency).
 
 There is two talks which where introducing the tilelink.fabric.Node. Those talk may not exactly follow the actual syntax, they are still follow the concepts : 
 
@@ -29,7 +29,7 @@ There is two talks which where introducing the tilelink.fabric.Node. Those talk 
 - In depth : https://peertube.f-si.org/videos/watch/bcf49c84-d21d-4571-a73e-96d7eb89e907
 
 Example Toplevel
--------------------
+----------------
 
 Here is an example of a simple fictive SoC toplevel :
 
@@ -53,7 +53,7 @@ You can also define intermediate nodes in the interconnect as following :
       ram.up at(0x10000, 0x200) of cpu.down
         
       // Create a peripherals namespace to keep things clean
-      val peripherals = new Area{
+      val peripherals = new Area {
         // Create a intermediate node in the interconnect
         val access = tilelink.fabric.Node()
         access at 0x20000 of cpu.down
@@ -67,7 +67,7 @@ You can also define intermediate nodes in the interconnect as following :
 
 
 Example GpioFiber
-----------------------
+-----------------
 
 GpioFiber is a simple tilelink peripheral which can read / drive a 32 bits tristate array.
 
@@ -126,7 +126,7 @@ RamFiber is the integration layer of a regular tilelink Ram component.
       val up = tilelink.fabric.Node.up()
 
       val thread = Fiber build new Area {
-        // Here the supported parameters are function of what the master would like us to idealy support.
+        // Here the supported parameters are function of what the master would like us to ideally support.
         // The tilelink.Ram support all addressWidth / dataWidth / burst length / get / put accesses
         // but doesn't support atomic / coherency. So we take what is proposed to use and restrict it to 
         // all sorts of get / put request
@@ -136,7 +136,7 @@ RamFiber is the integration layer of a regular tilelink Ram component.
         // Here we infer how many bytes our ram need to be, by looking at the memory mapping of the connected masters
         val bytes = up.ups.map(e => e.mapping.value.highestBound - e.mapping.value.lowerBound + 1).max.toInt
         
-        // Then we finaly generate the regular hardware
+        // Then we finally generate the regular hardware
         val logic = new tilelink.Ram(up.bus.p.node, bytes)
         logic.io.up << up.bus
       }
@@ -174,7 +174,7 @@ CpuFiber is an fictive example of a master integration.
                 tilelink.M2sSource(
                   id = SizeMapping(0, 4),
                   emits = M2sTransfers(
-                    get = tilelink.SizeRange(1, 64), //Meaning the get access can be any power of 2 size in [1, 64]
+                    get = tilelink.SizeRange(1, 64), // Meaning the get access can be any power of 2 size in [1, 64]
                     putFull = tilelink.SizeRange(1, 64)
                   )
                 )
@@ -186,7 +186,7 @@ CpuFiber is an fictive example of a master integration.
         // Lets say the CPU doesn't support any slave initiated requests (memory coherency)
         down.s2m.supported load tilelink.S2mSupport.none()
 
-        // Then we can generate some hardware (nothing usefull in this example)
+        // Then we can generate some hardware (nothing useful in this example)
         down.bus.a.setIdle()
         down.bus.d.ready := True
       }
@@ -199,7 +199,7 @@ To allow a master to identify what memory access it is allowed to do, you can us
 
         val mappings = spinal.lib.system.tag.MemoryConnection.getMemoryTransfers(down)
         // Here we just print the values out in stdout, but instead you can generate some hardware from it.
-        for(mapping <- mappings){
+        for(mapping <- mappings) {
           println(s"- ${mapping.where} -> ${mapping.transfers}")
         }
 
@@ -213,7 +213,7 @@ If you run this in the Cpu's fiber, in the following soc :
       ram.up at(0x10000, 0x200) of cpu.down
         
       // Create a peripherals namespace to keep things clean
-      val peripherals = new Area{
+      val peripherals = new Area {
         // Create a intermediate node in the interconnect
         val access = tilelink.fabric.Node()
         access at 0x20000 of cpu.down
@@ -237,7 +237,7 @@ You will get :
 - "SM" means SizeMapping(address, size)
 - "OT" means OffsetTransformer(offset)
 
-Note that you can also add PMA (Physical Memory Attributes) to nodes and retreives them via this getMemoryTransfers utilities.
+Note that you can also add PMA (Physical Memory Attributes) to nodes and retrieves them via this getMemoryTransfers utilities.
 
 The currently defined PMA are : 
 
@@ -262,9 +262,9 @@ The getMemoryTransfers utility rely on a dedicated SpinalTag :
     trait MemoryConnection extends SpinalTag {
       def up : Nameable with SpinalTagReady // Side toward the masters of the system
       def down : Nameable with SpinalTagReady // Side toward the slaves of the system
-      def mapping : AddressMapping //Specify the memory mapping of the slave from the master address (before transformers are applied)
-      def transformers : List[AddressTransformer]  //List of alteration done to the address on this connection (ex offset, interleaving, ...)
-      def sToM(downs : MemoryTransfers, args : MappedNode) : MemoryTransfers = downs //Convert the slave MemoryTransfers capabilities into the master ones
+      def mapping : AddressMapping // Specify the memory mapping of the slave from the master address (before transformers are applied)
+      def transformers : List[AddressTransformer]  // List of alteration done to the address on this connection (ex offset, interleaving, ...)
+      def sToM(downs : MemoryTransfers, args : MappedNode) : MemoryTransfers = downs // Convert the slave MemoryTransfers capabilities into the master ones
     }
 
 That SpinalTag can be used applied to both ends of a given memory bus connection to keep this connection discoverable at elaboration time, creating a graph of MemoryConnection. One good thing about it is that is is bus agnostic, meaning it isn't tilelink specific.
@@ -277,7 +277,7 @@ The width adapter is a simple example of bridge.
 
 .. code-block:: 
 
-    class WidthAdapterFiber() extends Area{
+    class WidthAdapterFiber() extends Area {
       val up = Node.up()
       val down = Node.down()
 
@@ -290,17 +290,17 @@ The width adapter is a simple example of bridge.
         populate()
       }
 
-      // Fiber in which we will negociate the data width parameters and generate the hardware
-      val logic = Fiber build new Area{
+      // Fiber in which we will negotiate the data width parameters and generate the hardware
+      val logic = Fiber build new Area {
         // First, we propagate downward the parameter proposal, hopping that the downward side will agree
         down.m2s.proposed.load(up.m2s.proposed)
 
-        // Second, we will propagate upward what is actualy supported, but will take care of any dataWidth missmatch
+        // Second, we will propagate upward what is actually supported, but will take care of any dataWidth mismatch
         up.m2s.supported load down.m2s.supported.copy(
           dataWidth = up.m2s.proposed.dataWidth
         )
 
-        // Third, we propagate downward the final bus parameter, but will take care of any dataWidth missmatch
+        // Third, we propagate downward the final bus parameter, but will take care of any dataWidth mismatch
         down.m2s.parameters load up.m2s.parameters.copy(
           dataWidth = down.m2s.supported.dataWidth
         )
@@ -308,7 +308,7 @@ The width adapter is a simple example of bridge.
         // No alteration on s2m parameters
         up.s2m.from(down.s2m)
 
-        // Finaly, we generate the hardware
+        // Finally, we generate the hardware
         val bridge = new tilelink.WidthAdapter(up.bus.p, down.bus.p)
         bridge.io.up << up.bus
         bridge.io.down >> down.bus

--- a/source/SpinalHDL/Libraries/Com/spiXdr.rst
+++ b/source/SpinalHDL/Libraries/Com/spiXdr.rst
@@ -1,6 +1,6 @@
 
 SPI XDR
-========
+=======
 
 There is a SPI controller which support :
 
@@ -14,7 +14,7 @@ You can find its APB3 implementation here :
 https://github.com/SpinalHDL/SpinalHDL/blob/68b6158700fc2440ea7980406f927262c004faca/lib/src/main/scala/spinal/lib/com/spi/xdr/Apb3SpiXdrMasterCtrl.scala#L43
 
 Configuration
-----------------------------
+-------------
 
 Here is an example.
 
@@ -24,11 +24,11 @@ Here is an example.
         SpiXdrMasterCtrl.MemoryMappingParameters(
           SpiXdrMasterCtrl.Parameters(
             dataWidth = 8, // Each transfer will be 8 bits
-            timerWidth = 12, // The timer is used to slow down the transmition
-            spi = SpiXdrParameter( //Specify the physical SPI interface
-              dataWidth = 4, //Number of physical SPI data pins
-              ioRate = 1, //Specify the number of transfer that each spi pin can do per clock 1 => SDR, 2 => DDR
-              ssWidth = 1 //Number of chip selects
+            timerWidth = 12, // The timer is used to slow down the transmission
+            spi = SpiXdrParameter( // Specify the physical SPI interface
+              dataWidth = 4, // Number of physical SPI data pins
+              ioRate = 1, // Specify the number of transfer that each spi pin can do per clock 1 => SDR, 2 => DDR
+              ssWidth = 1 // Number of chip selects
             )
           )
           .addFullDuplex(id = 0) // Add support for regular SPI (MISO / MOSI) using the mode id 0
@@ -38,7 +38,7 @@ Here is an example.
                       // When rate bigger (ex 2), the controller will ignore the timer, and use the SpiXdrParameter.ioRate
                       // capabilities to emit up to "rate" transition per clock cycle.
             ddr = false, // sdr => 1 bit per SPI clock, DDR => 2 bits per SPI clock
-            spiWidth = 4 //Number of physical SPI data pin used for serialisation
+            spiWidth = 4 // Number of physical SPI data pin used for serialization
           ),
           cmdFifoDepth = 32,
           rspFifoDepth = 32,
@@ -47,7 +47,7 @@ Here is an example.
       )
 
 Software Driver
-----------------------------
+---------------
 
 See :
 

--- a/source/SpinalHDL/Libraries/Com/usb_device.rst
+++ b/source/SpinalHDL/Libraries/Com/usb_device.rst
@@ -4,14 +4,14 @@ USB device
 
 Here exists a USB device controller in the SpinalHDL library.
 
-A few bullet points to summarise support:
+A few bullet points to summarize support:
 
 - Implemented to allow a CPU to configure and manage the endpoints
 - A internal ram which store the endpoints states and transactions descriptors
-- Up to 16 endpoints (for virtualy no price)
-- Support USB host full speed (12Mbps)
+- Up to 16 endpoints (for virtually no price)
+- Support USB host full speed (12 Mbps)
 - Test on linux using its own driver (https://github.com/SpinalHDL/linux/blob/dev/drivers/usb/gadget/udc/spinal_udc.c)
-- Bmb memory interace for the configuration
+- Bmb memory interface for the configuration
 - Require a clock for the internal phy which is a multiple of 12 Mhz at least 48 Mhz
 - The controller frequency is not restricted
 - No external phy required
@@ -50,7 +50,7 @@ Registers
 Note that all registers and memories of the controller are only accessible in 32 bits word access, bytes access isn't supported.
 
 FRAME (0xFF00)
-**********************
+**************
 
 +-------------------------+------+-----------+------------------------------------------------------------------+
 | Name                    | Type | Bits      | Description                                                      |
@@ -60,26 +60,26 @@ FRAME (0xFF00)
 
 
 ADDRESS (0xFF04)
-**********************
+****************
 
 +-------------------------+------+-----------+------------------------------------------------------------------+
 | Name                    | Type | Bits      | Description                                                      |
 +=========================+======+===========+==================================================================+
 | address                 |  WO  | 6-0       | The device will only listen at tokens with the specified address |
-|                         |      |           | This field is automaticaly cleared on usb reset events           |
+|                         |      |           | This field is automatically cleared on usb reset events          |
 +-------------------------+------+-----------+------------------------------------------------------------------+
 | enable                  |  WO  | 8         | Enable the USB address filtering if set                          |
 +-------------------------+------+-----------+------------------------------------------------------------------+
-| trigger                 |  WO  | 9         | Set the enable (see above) on the next EP0 IN tocken completion  |
+| trigger                 |  WO  | 9         | Set the enable (see above) on the next EP0 IN token completion   |
 |                         |      |           | Cleared by the hardware after any EP0 completion                 |
 +-------------------------+------+-----------+------------------------------------------------------------------+
 
 The idea here is to keep the whole register cleared until a USB SET_ADDRESS setup packet is received on EP0.
 At that moment, you can set the address and the trigger field, then provide the IN zero length descriptor to EP0 to 
-finalise the SET_ADDRESS sequance. The controller will then automaticaly turn on the address filtering at the completion of that descriptor.
+finalize the SET_ADDRESS sequence. The controller will then automatically turn on the address filtering at the completion of that descriptor.
 
 INTERRUPT (0xFF08)
-**********************
+******************
 
 Individual bits of this register can be cleared by writing '1' in them.
 Reading this register returns the current interrupt status.
@@ -101,7 +101,7 @@ Reading this register returns the current interrupt status.
 +--------------+-------+-----------+------------------------------------------------------------------+
 
 HALT (0xFF0C)
-**********************
+*************
 
 This register allows placement of a single endpoint into a dormant state in order to ensure atomicity of CPU operations, allowing to do things as read/modify/write on the endpoint registers and descriptors.
 The peripheral will return NAK if the given endpoint is addressed by the usb host while halt is enabled and the endpoint is enabled.
@@ -118,7 +118,7 @@ The peripheral will return NAK if the given endpoint is addressed by the usb hos
 +-------------------------+------+-----------+------------------------------------------------------------------+
 
 CONFIG (0xFF10)
-**********************
+***************
 
 +-------------------------+------+-----------+------------------------------------------------------------------+
 | Name                    | Type | Bits      | Description                                                      |
@@ -133,7 +133,7 @@ CONFIG (0xFF10)
 +-------------------------+------+-----------+------------------------------------------------------------------+
 
 INFO (0xFF20)
-**********************
+*************
 
 +---------------+------+-----------+------------------------------------------------------------------+
 | Name          | Type | Bits      | Description                                                      |
@@ -142,14 +142,14 @@ INFO (0xFF20)
 +---------------+------+-----------+------------------------------------------------------------------+
 
 ENDPOINTS (0x0000 - 0x003F)
-*********************************
+***************************
 
-The endpoints status are stored at the begining of the internal ram over one 32 bits word each.
+The endpoints status are stored at the beginning of the internal ram over one 32 bits word each.
 
 +---------------+------+-----------+------------------------------------------------------------------+
 | Name          | Type | Bits      | Description                                                      |
 +===============+======+===========+==================================================================+
-| enable        |  RW  | 0         | If not set, the endpoint will ignore all the trafic              |
+| enable        |  RW  | 0         | If not set, the endpoint will ignore all the traffic             |
 +---------------+------+-----------+------------------------------------------------------------------+
 | stall         |  RW  | 1         | If set, the endpoint will always return STALL status             |
 +---------------+------+-----------+------------------------------------------------------------------+
@@ -177,7 +177,7 @@ Then the there is a few cases :
 - Either you have at least one descriptor pointed by head, in which case it will execute it and ACK if all was going smooth
 
 SETUP_DATA (0x0040 - 0x0047)
-*********************************
+****************************
 
 When endpoint 0 receives a SETUP transaction, the data of the transaction will be stored in this location. 
 
@@ -217,7 +217,7 @@ They are stored in the internal ram, can be linked together via their linked lis
 
 Note, if the controller receives a frame where the IN/OUT does not match the descriptor IN/OUT, the frame will be ignored.
 
-Also, to initialise a descriptor, the CPU should set the code field to 0xF
+Also, to initialize a descriptor, the CPU should set the code field to 0xF
 
 Usage
 -----
@@ -260,7 +260,7 @@ Usage
     }
 
 
-    object UsbDeviceGen extends App{
+    object UsbDeviceGen extends App {
       SpinalVerilog(new UsbDeviceTop())
     }
 

--- a/source/SpinalHDL/Libraries/Com/usb_ohci.rst
+++ b/source/SpinalHDL/Libraries/Com/usb_ohci.rst
@@ -4,15 +4,15 @@ USB OHCI
 
 Here exists a USB OHCi controller (host) in the SpinalHDL library.
 
-A few bullet points to summarise support:
+A few bullet points to summarize support:
 
 - It follow the `OpenHCI Open Host Controller Interface Specification for USB` specification (OHCI).
 - It is compatible with the upstream linux / uboot OHCI drivers already. (there is also an OHCI driver on tinyUSB)
-- This provides USB host full speed and low speed capabilities (12Mbps and 1.5Mbps)
+- This provides USB host full speed and low speed capabilities (12 Mbps and 1.5 Mbps)
 - Tested on linux and uboot
 - One controller can host multiple ports (up to 16)
 - Bmb memory interface for DMA accesses
-- Bmb memory interace for the configuration
+- Bmb memory interface for the configuration
 - Requires a clock for the internal phy which is a multiple of 12 Mhz at least 48 Mhz
 - The controller frequency is not restricted
 - No external phy required
@@ -79,8 +79,8 @@ Usage
         powerSwitchingMode = true,
         noOverCurrentProtection = true,
         powerOnToPowerGoodTime = 10,
-        dataWidth = 64, //DMA data width, up to 128
-        portsConfig = List.fill(4)(OhciPortParameter()) //4 Ports
+        dataWidth = 64, // DMA data width, up to 128
+        portsConfig = List.fill(4)(OhciPortParameter()) // 4 Ports
       )
 
       SpinalVerilog(new UsbOhciTop(p))

--- a/source/SpinalHDL/Libraries/EDA/altera/qsysify.rst
+++ b/source/SpinalHDL/Libraries/EDA/altera/qsysify.rst
@@ -2,7 +2,7 @@
 QSysify
 =======
 
-QSysify is a tool which is able to generate a QSys IP (tcl script) from a SpinalHDL component by analysing its IO definition. It currently implement the following interfaces features :
+QSysify is a tool which is able to generate a QSys IP (tcl script) from a SpinalHDL component by analyzing its IO definition. It currently implement the following interfaces features :
 
 * Master/Slave AvalonMM
 * Master/Slave APB3
@@ -24,7 +24,7 @@ In the case of a UART controller :
        val uart = master(Uart())
      }
 
-     //...
+     // ...
    }
 
 The following  ``main`` will generate the Verilog and the QSys TCL script with io.bus as an AvalonMM and io.uart as a conduit :
@@ -33,13 +33,13 @@ The following  ``main`` will generate the Verilog and the QSys TCL script with i
 
    object AvalonMMUartCtrl {
      def main(args: Array[String]) {
-       //Generate the Verilog
+       // Generate the Verilog
        val toplevel = SpinalVerilog(AvalonMMUartCtrl(UartCtrlMemoryMappedConfig(...))).toplevel
 
-       //Add some tags to the avalon bus to specify it's clock domain (information used by QSysify)
+       // Add some tags to the avalon bus to specify it's clock domain (information used by QSysify)
        toplevel.io.bus addTag(ClockDomainTag(toplevel.clockDomain))
 
-       //Generate the QSys IP (tcl script)
+       // Generate the QSys IP (tcl script)
        QSysify(toplevel)
      }
    }

--- a/source/SpinalHDL/Libraries/Graphics/vga.rst
+++ b/source/SpinalHDL/Libraries/Graphics/vga.rst
@@ -15,7 +15,7 @@ An VGA bus definition is available via the Vga bundle.
      val vSync = Bool()
      val hSync = Bool()
 
-     val colorEn = Bool()  //High when the frame is inside the color area
+     val colorEn = Bool()  // High when the frame is inside the color area
      val color = Rgb(rgbConfig)
 
      override def asMaster() = this.asOutput()

--- a/source/SpinalHDL/Libraries/Misc/PLIC/plic_mapper.rst
+++ b/source/SpinalHDL/Libraries/Misc/PLIC/plic_mapper.rst
@@ -33,9 +33,9 @@ Follows the SiFive PLIC mapping (eg. `E31 core complex Manual <https://sifive.cd
 ----------------------------
 This mapping generates a lighter PLIC, at the cost of some missing optional features:
 
-* no reading the intrerrupt's priority
-* no reading the interrupts's pending bit (must use the claim/complete mechanism)
-* no reading the target's threshold
+* not reading the interrupt's priority
+* not reading the interrupt's pending bit (must use the claim/complete mechanism)
+* not reading the target's threshold
 
 The rest of the registers & logic is generated.
 

--- a/source/SpinalHDL/Libraries/Misc/service_plugin.rst
+++ b/source/SpinalHDL/Libraries/Misc/service_plugin.rst
@@ -2,17 +2,17 @@
    :format: html
 
 Plugin
-==========================
+======
 
 Introduction
---------------------
+------------
 
 For some design, instead of implementing your Component's hardware directly in it, 
 you may instead want to compose its hardware by using some sorts of Plugins. This can provide a few key features : 
 
 - You can extend the features of your component by adding new plugins in its parameters. For instance adding Floating point support in a CPU.
 - You can swap various implementations of the same functionality just by using another set of plugins. For instance one implementation of a CPU multiplier may fit well on some FPGA, while others may fit well on ASIC.
-- It avoid the very very very large hand written toplevel syndrom where everything has to be connected manualy. Instead plugins can discover their neighborhood by looking/using the software interface of other plugins.
+- It avoid the very very very large hand written toplevel syndrome where everything has to be connected manually. Instead plugins can discover their neighborhood by looking/using the software interface of other plugins.
 
 VexRiscv and NaxRiscv projects are an example of this. Their are CPUs which have a mostly empty toplevel, 
 and their hardware parts are injected using plugins. For instance : 
@@ -24,7 +24,7 @@ and their hardware parts are injected using plugins. For instance :
 - IntAluPlugin
 - ...
 
-And those plugins will then negociate/propagate/interconnect to each others via their pool of services.
+And those plugins will then negotiate/propagate/interconnect to each others via their pool of services.
 
 While VexRiscv use a strict synchronous 2 phase system (setup/build callback), NaxRiscv uses a more flexible approach which uses the spinal.core.fiber API to fork elaboration threads which can interlock each others in order to ensure a workable elaboration ordering.
 
@@ -35,8 +35,8 @@ Execution order
 
 The main idea is that you have multiple 2 executions phases : 
 
-- Setup phase, in which plugins can lock/retain each others. The idea is not to start negociation / elaboration yet.
-- Build phase, in which plugins can negociation / elaboration hardware.
+- Setup phase, in which plugins can lock/retain each others. The idea is not to start negotiation / elaboration yet.
+- Build phase, in which plugins can negotiation / elaboration hardware.
 
 The build phase will not start before all FiberPlugin are done with their setup phase.
 
@@ -58,7 +58,7 @@ The build phase will not start before all FiberPlugin are done with their setup 
 
 
 Simple example
---------------------
+--------------
 
 Here is a simple dummy example with a SubComponent which will be composed using 2 plugins :
 
@@ -82,7 +82,7 @@ Here is a simple dummy example with a SubComponent which will be composed using 
 
       // Let's define a plugin which will make the StatePlugin's register increment
       class DriverPlugin extends FiberPlugin {
-        // We define how to get the instance of StatePlugin.logic from the PluginHost. It is a lazy val, because we can't evaluate it until the plugin is binded to its host.
+        // We define how to get the instance of StatePlugin.logic from the PluginHost. It is a lazy val, because we can't evaluate it until the plugin is bound to its host.
         lazy val sp = host[StatePlugin].logic.get
 
         val logic = during build new Area {
@@ -110,8 +110,8 @@ Such TopLevel would generate the following Verilog code :
 
 
       SubComponent sub (
-        .clk   (clk  ), //i
-        .reset (reset)  //i
+        .clk   (clk  ), // i
+        .reset (reset)  // i
       );
 
     endmodule
@@ -121,10 +121,10 @@ Such TopLevel would generate the following Verilog code :
       input  wire          reset
     );
 
-      reg        [31:0]   StatePlugin_logic_signal; //Created by StatePlugin
+      reg        [31:0]   StatePlugin_logic_signal; // Created by StatePlugin
 
       always @(posedge clk) begin
-        StatePlugin_logic_signal <= (StatePlugin_logic_signal + 32'h00000001); //incremented by DriverPlugin
+        StatePlugin_logic_signal <= (StatePlugin_logic_signal + 32'h00000001); // incremented by DriverPlugin
       end
     endmodule
 
@@ -200,7 +200,7 @@ the SetupPlugin uses the DriverPlugin.retain/release functions.
       new DriverPlugin(),
       new StatePlugin(),
       new SetupPlugin(),
-      new SetupPlugin() //Let's add a second SetupPlugin, because we can
+      new SetupPlugin() // Let's add a second SetupPlugin, because we can
     )
   }
 
@@ -215,8 +215,8 @@ Here is the generated verilog
 
 
       SubComponent sub (
-        .clk   (clk  ), //i
-        .reset (reset)  //i
+        .clk   (clk  ), // i
+        .reset (reset)  // i
       );
 
     endmodule
@@ -235,6 +235,6 @@ Here is the generated verilog
 
 Clearly, those examples are overkilled for what they do, the idea in general is more about : 
 
-- Negociate / create interfaces between plugins (ex jump / flush ports)
+- Negotiate / create interfaces between plugins (ex jump / flush ports)
 - Schedule the elaboration (ex decode / dispatch specification)
 - Provide a distributed framework which can scale up (minimal hardcoding)

--- a/source/SpinalHDL/Libraries/Pipeline/introduction.rst
+++ b/source/SpinalHDL/Libraries/Pipeline/introduction.rst
@@ -6,7 +6,7 @@ spinal.lib.misc.pipeline provides a pipelining API. The main advantages over man
 
 - You don't have to predefine all the signal elements needed for the entire staged system upfront. You can create and consume stagable signals in a more ad hoc fashion as your design requires - without needing to refactor all the intervening stages to know about the signal
 - Signals of the pipeline can utilize the powerful parametrization capabilities of SpinalHDL and be subject to optimization/removal if a specific design build does not require a particular parametrized feature, without any need to modify the staging system design or project code base in a significant way.
-- Manual retiming is much easier, as you don't have to handle the registers / arbitration manualy
+- Manual retiming is much easier, as you don't have to handle the registers / arbitration manually
 - Manage the arbitration by itself
 
 The API is composed of 4 main things : 
@@ -29,7 +29,7 @@ Here is a video about this API :
 - https://www.youtube.com/watch?v=74h_-FMWWIM
 
 Simple example
-----------------
+--------------
 
 Here is a simple example which only uses the basics of the API :
 
@@ -42,7 +42,7 @@ Here is a simple example which only uses the basics of the API :
     import spinal.lib.misc.pipeline._
 
     class TopLevel extends Component {
-      val io = new Bundle{
+      val io = new Bundle {
         val up = slave Stream (UInt(16 bits))
         val down = master Stream (UInt(16 bits))
       }
@@ -115,8 +115,8 @@ Here is the same example but using more of the API :
     class TopLevel extends Component {
       val VALUE = Payload(UInt(16 bits))
 
-      val io = new Bundle{
-        val up = slave Stream(VALUE)  //VALUE can also be used as a HardType
+      val io = new Bundle {
+        val up = slave Stream(VALUE)  // VALUE can also be used as a HardType
         val down = master Stream(VALUE)
       }
       
@@ -124,13 +124,13 @@ Here is the same example but using more of the API :
       val builder = new NodesBuilder()
 
       // Let's define a Node which connect from io.up
-      val n0 = new builder.Node{
+      val n0 = new builder.Node {
         arbitrateFrom(io.up)
         VALUE := io.up.payload
       }
 
       // Let's define a Node which do some processing
-      val n1 = new builder.Node{
+      val n1 = new builder.Node {
         val RESULT = insert(VALUE + 0x1200)
       }
 
@@ -145,9 +145,9 @@ Here is the same example but using more of the API :
     }
 
 Payload
-============
+=======
 
-Payload objects are used to refer to data which can go through the pipeline. Technicaly speaking, Payload is a HardType which has a name and is used as a "key" to retrieve the signals in a certain pipeline stage.
+Payload objects are used to refer to data which can go through the pipeline. Technically speaking, Payload is a HardType which has a name and is used as a "key" to retrieve the signals in a certain pipeline stage.
 
 .. code-block:: scala
     
@@ -163,7 +163,7 @@ Payload objects are used to refer to data which can go through the pipeline. Tec
 Note that I got used to name the Payload instances using uppercase. This is to make it very explicit that the thing isn't a hardware signal, but are more like a "key/type" to access things.
 
 Node
-============
+====
 
 Node mostly hosts the valid/ready arbitration signals, and the hardware signals required for all the Payload values going through it.
 
@@ -182,7 +182,7 @@ You can access its arbitration via :
      - Is the signal which specifies if a transaction is present on the node. It is driven by the upstream. Once asserted, it must only be de-asserted the cycle after which either both valid and ready or node.cancel are high. valid must not depend on ready.
    * - node.ready
      - RW
-     - Is the signal which specifies if the node's transaction can proceed downstream. It is driven by the downstream to create backpresure. The signal has no meaning when there is no transaction (node.valid being deasserted)
+     - Is the signal which specifies if the node's transaction can proceed downstream. It is driven by the downstream to create backpressure. The signal has no meaning when there is no transaction (node.valid being deasserted)
    * - node.cancel
      - RW
      - Is the signal which specifies if the node's transaction in being canceled from the pipeline. It is driven by the downstream. The signal has no meaning when there is no transaction (node.valid being deasserted)
@@ -197,7 +197,7 @@ You can access its arbitration via :
      - node.cancel's read only accessor
    * - node.isFiring
      - RO
-     - True when the node transaction is successfuly moving futher (valid && ready && !cancel). Useful to commit state changes.
+     - True when the node transaction is successfully moving further (valid && ready && !cancel). Useful to commit state changes.
    * - node.isMoving
      - RO
      - True when the node transaction will not be present anymore on the node (starting from the next cycle),
@@ -209,8 +209,8 @@ You can access its arbitration via :
 
 Note that the node.valid/node.ready signals follows the same conventions than the :doc:`../stream`'s ones .
 
-The Node controls (valid/ready/cancel) and status (isValid, isReady, isCancel, isFiring, ...) signals are created on demande.
-So for instance you can create pipeline with no backpresure by never refering to the ready signal. That's why it is important to use status signals when you want to read the status of something and only use control signals when you to drive something.
+The Node controls (valid/ready/cancel) and status (isValid, isReady, isCancel, isFiring, ...) signals are created on demand.
+So for instance you can create pipeline with no backpressure by never referring to the ready signal. That's why it is important to use status signals when you want to read the status of something and only use control signals when you to drive something.
 
 Here is a list of arbitration cases you can have on a node. valid/ready/cancel define the state we are in, while isFiring/isMoving result of those :
 
@@ -254,11 +254,11 @@ You can access signals referenced by a Payload via:
     n0(PC) := 0x42
     n0(PC, "true") := 0x42
     n0(PC, 0x666) := 0xEE
-    val SOMETHING = n0.insert(myHardwareSignal) //This create a new Payload
+    val SOMETHING = n0.insert(myHardwareSignal) // This create a new Payload
     when(n1(SOMETHING) === 0xFFAA){ ... }
     
 
-While you can manualy drive/read the arbitration/data of the first/last stage of your pipeline, there is a few utilities to connect its boundaries.
+While you can manually drive/read the arbitration/data of the first/last stage of your pipeline, there is a few utilities to connect its boundaries.
 
 
 .. list-table::
@@ -296,7 +296,7 @@ While you can manualy drive/read the arbitration/data of the first/last stage of
 
     // Define the input / output stream that will be later connected to the pipeline
     val up = slave Stream(UInt(16 bits))
-    val down = master Stream(UInt(16 bits)) //Note master Stream(OUT) is good aswell
+    val down = master Stream(UInt(16 bits)) // Note master Stream(OUT) is good as well
 
     n0.driveFrom(up)((self, payload) => self(IN) := payload)
     n2.driveTo(down)((payload, self) => payload := self(OUT))
@@ -307,7 +307,7 @@ In order to reduce verbosity, there is a set of implicit conversions between Pay
 .. code-block:: scala
 
     val VALUE = Payload(UInt(16 bits))
-    val n1 = new Node{
+    val n1 = new Node {
         val PLUS_ONE = insert(VALUE + 1) // VALUE is implicitly converted into its n1(VALUE) representation
     }
 
@@ -324,14 +324,14 @@ You can also use those implicit conversions by importing them :
     }
 
 
-There is also an API which alows you to create new Area which provide the whole API of a given node instance (including implicit convertion) without import : 
+There is also an API which allows you to create new Area which provide the whole API of a given node instance (including implicit conversion) without import : 
 
 .. code-block:: scala
 
     val n1 = Node()
     val VALUE = Payload(UInt(16 bits))
 
-    val n1Stuff = new n1.Area{
+    val n1Stuff = new n1.Area {
         val PLUS_ONE = insert(VALUE) + 1 // Equivalent to n1.insert(n1(VALUE)) + 1
     }
 
@@ -339,14 +339,14 @@ Such feature is very useful when you have parametrizable pipeline locations for 
 
 
 Links
-============
+=====
 
 There is few different Links already implemented (but you could also create your own custom one).
 The idea of Links is to connect two nodes together in various ways.
 They generally have a `up` Node and a `down` Node.
 
 DirectLink
-------------------
+----------
 
 Very simple, it connect two nodes with wires only. Here is an example : 
 
@@ -358,7 +358,7 @@ Very simple, it connect two nodes with wires only. Here is an example :
 
 
 StageLink
-------------------
+---------
 
 This connect two nodes using registers on the data / valid signals and some arbitration on the ready.
 
@@ -368,16 +368,16 @@ This connect two nodes using registers on the data / valid signals and some arbi
 
 
 S2mLink
-------------------
+-------
 
-This connect two nodes using registers on the ready signal, which can be useful to improve backpresure combinatorial timings.
+This connect two nodes using registers on the ready signal, which can be useful to improve backpressure combinatorial timings.
 
 .. code-block:: scala
     
     val c01 = S2mLink(n0, n1)
 
 CtrlLink
-------------------
+--------
 
 This is kind of a special Link, as connect two nodes with optional flow control / bypass logic. Its API should be flexible enough to implement a CPU stage with it.
 
@@ -412,7 +412,7 @@ Also note that if you want to do flow control in a conditional scope (ex in a wh
 
     c01.haltWhen(something) // Explicit halt request
 
-    when(somethingElse){
+    when(somethingElse) {
         c01.haltIt() // Conditional scope sensitive halt request, same as c01.haltWhen(somethingElse)
     }
 
@@ -433,7 +433,7 @@ The CtrlLink also provide an API to access Payload :
    * - link.insert(Data)
      - Same as Link.down.insert(Data)
    * - link.bypass(Payload)
-     - Allows to conditionaly override a Payload value between link.up -> link.down. This can be used to fix data hazard in CPU pipelines for instance.
+     - Allows to conditionally override a Payload value between link.up -> link.down. This can be used to fix data hazard in CPU pipelines for instance.
 
 
 .. code-block:: scala
@@ -446,7 +446,7 @@ The CtrlLink also provide an API to access Payload :
 
     val DATA = Payload(UInt(32 bits))
     // Let's say Data is inserted in the pipeline before c01
-    when(hazard){
+    when(hazard) {
         c01.bypass(DATA) := fixedValue
     }
     
@@ -463,18 +463,18 @@ Note that if you create a CtrlLink without node arguments, it will create its ow
 
 
 Other Links
-------------------------------------
+-----------
 
 There is also a JoinLink / ForkLink implemented.
 
 Your custom Link
-------------------------------------
+----------------
 
 You can implement your custom links by implementing the Link base class.
 
 .. code-block:: scala
 
-    trait Link extends Area{
+    trait Link extends Area {
       def ups : Seq[Node]
       def downs : Seq[Node]
 
@@ -486,7 +486,7 @@ You can implement your custom links by implementing the Link base class.
 But that API may change a bit, as it is still fresh.
 
 Builder
-============
+=======
 
 To generate the hardware of your pipeline, you need to give a list of all the Links used in your pipeline.
 
@@ -503,7 +503,7 @@ To generate the hardware of your pipeline, you need to give a list of all the Li
       // Let's ask the builder to generate all the required hardware
       Builder(s01, s12)
 
-There is also a set of "all in one" builders that you can instanciate to help yourself. 
+There is also a set of "all in one" builders that you can instantiate to help yourself. 
 
 For instance there is the NodesBuilder class which can be used to create sequentially staged pipelines : 
 
@@ -518,7 +518,7 @@ For instance there is the NodesBuilder class which can be used to create sequent
       builder.genStagedPipeline()
 
 Composability
-========================
+=============
 
 One good thing about the API is that it easily allows to compose a pipeline with multiple parallel things. What i mean by "compose" is that sometime the pipeline you need to design has parallel processing to do. 
 
@@ -541,7 +541,7 @@ The example below show a pattern which composes a pipeline with multiple lanes t
     // which carries 'lanesCount' values that we want to process in parallel
     // and put the result on an output stream
     class TopLevel(lanesCount : Int) extends Component {
-      val io = new Bundle{
+      val io = new Bundle {
         val up = slave Stream(Vec.fill(lanesCount)(UInt(16 bits))) 
         val down = master Stream(Vec.fill(lanesCount)(UInt(16 bits)))
       }
@@ -568,14 +568,14 @@ The example below show a pattern which composes a pipeline with multiple lanes t
       Builder(s01, s12)
     }
 
-This will produce the following data path (assuming lanesCount = 2), abitration not being shown :
+This will produce the following data path (assuming lanesCount = 2), arbitration not being shown :
 
 .. image:: /asset/image/pipeline/composable_lanes.png
    :scale: 70 %
 
 
-Retiming / Variable lenth
-================================================
+Retiming / Variable length
+==========================
 
 Sometime you want to design a pipeline, but you don't really know where the critical paths will be and what the right balance between stages is. And often you can't rely on the synthesis tool doing a good job with automatic retiming.
 
@@ -636,7 +636,7 @@ Here is how it can be done with this pipelining API :
         io.down.payload := multiplier.MUL
       }
 
-      // Let's connect those nodes sequencialy by using simples registers
+      // Let's connect those nodes sequentially by using simples registers
       val links = for (i <- 0 to resultAt - 1) yield StageLink(nodes(i), nodes(i + 1))
 
       // Let's ask the builder to generate all the required hardware
@@ -814,7 +814,7 @@ One thing about this example is the necessity intermediate val as `addNode`. I m
         ...
       }
 
-Unfortunatly, scala doesn't allow to replace `new addNode.Area` with `new nodes(addAt).Area`.
+Unfortunately, scala doesn't allow to replace `new addNode.Area` with `new nodes(addAt).Area`.
 One workaround is to define a class as : 
 
 .. code-block:: scala
@@ -827,7 +827,7 @@ One workaround is to define a class as :
 Depending the scale of your pipeline, it can payoff.
 
 Simple CPU example
-================================================
+==================
 
 Here is a simple/stupid 8 bits CPU example with : 
 
@@ -847,7 +847,7 @@ Here is a simple/stupid 8 bits CPU example with :
 
     val led = out(Reg(Bits(8 bits))) init(0)
 
-    val fetcher = new fetch.Area{
+    val fetcher = new fetch.Area {
       val pcReg = Reg(PC) init (0)
       up(PC) := pcReg
       up.valid := True
@@ -859,7 +859,7 @@ Here is a simple/stupid 8 bits CPU example with :
       INSTRUCTION := mem.readAsync(PC)
     }
 
-    val decoder = new decode.Area{
+    val decoder = new decode.Area {
       val opcode = INSTRUCTION(7 downto 0)
       val IS_ADD   = insert(opcode === 0x1)
       val IS_JUMP  = insert(opcode === 0x2)
@@ -868,7 +868,7 @@ Here is a simple/stupid 8 bits CPU example with :
     }
 
 
-    val alu = new execute.Area{
+    val alu = new execute.Area {
       val regfile = Reg(UInt(8 bits)) init(0)
       
       val flush = False

--- a/source/SpinalHDL/Libraries/fiber.rst
+++ b/source/SpinalHDL/Libraries/fiber.rst
@@ -4,13 +4,13 @@
 .. _fiber:
 
 Fiber framework
-====================
+===============
 
 .. warning::
    This framework is not expected to be used for general RTL generation and targets large system
    design management and code generation. It is currently used as toplevel integration tool in SaxonSoC.
 
-Currently in developpement.
+Currently in development.
 
 The Fiber to run the hardware elaboration in a out of order manner, a bit similarly to Makefile, where you can define rules and dependencies which will then be solved when you run a make command. It is very similar to the Scala Future feature.
 
@@ -18,7 +18,7 @@ Using this framework can complicate simple things but provide some strong featur
 
 - You can define things before even knowing all their requirements, ex :
   instantiating a interruption controller, before knowing how many interrupt signal lines you need
-- Abstract/lazy/partial SoC architecture definition allowing the creation of SoC template for further specialisations
+- Abstract/lazy/partial SoC architecture definition allowing the creation of SoC template for further specializations
 - Automatic requirement negotiation between multiple agents in a decentralized way, ex : between masters and slaves of a memory bus
 
 The framework is mainly composed of : 
@@ -71,20 +71,20 @@ So, the main point of that example is to show that we kind of overcome the seque
 
 
 Handle[T]
---------------------
+---------
 
 Handle[T] are a bit like scala's Future[T], they allow to talk about something before it is even existing, and wait on it.
 
 .. code-block:: scala
     
     val x,y = Handle[Int]
-    val xPlus2 : Handle[Int] = x.produce(x.get + 2) //x.produce can be used to generate a new Handle when x is loaded
-    val xPlus3 : Handle[Int] = x.derivate(_ + 3)    //x.derivate is as x.produce, but also provide the x.get as argument of the lambda function
-    x.load(3) //x will now contain the value 3
+    val xPlus2 : Handle[Int] = x.produce(x.get + 2) // x.produce can be used to generate a new Handle when x is loaded
+    val xPlus3 : Handle[Int] = x.derivate(_ + 3)    // x.derivate is as x.produce, but also provide the x.get as argument of the lambda function
+    x.load(3) // x will now contain the value 3
 
 
 soon(handle)
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 In order to maintain a proper graph of dependencies between tasks and Handle, a task can specify in advance that it will load a given handle. This is very usefull in case of a generation starvation/deadlock for SpinalHDL to report accuratly where is the issue.
 

--- a/source/SpinalHDL/Libraries/flow.rst
+++ b/source/SpinalHDL/Libraries/flow.rst
@@ -50,7 +50,7 @@ Functions
      - Flow[T]
      - 
    * - x.m2sPipe()
-     - | Return a Flow drived by x
+     - | Return a Flow driven by x
        | through a register stage that cut valid/payload paths
      - Flow[T]
      - 1

--- a/source/SpinalHDL/Libraries/fsm.rst
+++ b/source/SpinalHDL/Libraries/fsm.rst
@@ -144,7 +144,7 @@ State encoding
 ^^^^^^^^^^^^^^
 
 By default the FSM state vector will be encoded using the native encoding of the language/tools the RTL is generated for (Verilog or VHDL).
-This default can be overriden by using the ``setEncoding(...)`` method which either takes a ``SpinalEnumEncoding`` or
+This default can be overridden by using the ``setEncoding(...)`` method which either takes a ``SpinalEnumEncoding`` or
 varargs of type ``(State, BigInt)`` for a custom encoding. 
 
 .. code-block:: scala
@@ -309,7 +309,7 @@ Notes about the entry state
 
 The way the entry state has been defined above makes it so that between the reset and the first clock sampling, the state machine is in a boot state. It is only after the first clock sampling that the defined entry state becomes active. This allows to properly enter the entry state (applying statements in ``onEntry``), and allows nested state machines.
 
-While it is usefull, it is also possible to bypass that feature and directly having a state machine booting into a user state.
+While it is useful, it is also possible to bypass that feature and directly having a state machine booting into a user state.
 
 To do so, use `makeInstantEntry()` instead of defining a ``new State``. This function returns the boot state, active directly after reset.
 
@@ -337,7 +337,7 @@ Example:
 
 .. code-block:: scala
 
-    //  State sequance : BOOT, IDLE, STATE_A, STATE_B, ...
+    //  State sequence : BOOT, IDLE, STATE_A, STATE_B, ...
     val fsm = new StateMachine {
       val IDLE, STATE_A, STATE_B, STATE_C = new State
       setEntry(IDLE)

--- a/source/SpinalHDL/Libraries/generator.old
+++ b/source/SpinalHDL/Libraries/generator.old
@@ -4,7 +4,7 @@
 .. _generator:
 
 Generator framework
-====================
+===================
 
 Deprecated (This framework is now replaced by the fiber one)
 
@@ -12,8 +12,8 @@ The generator framework allow to specify and run the hardware elaboration in a o
 
 Such framework complexify simple things but provide some strong feature for complex cases :
 
-- You can define things before even knowing all their requirements, ex : instanciating a interruption controller, before knowing how many lines of interrupt you need
-- Abstract/lazy/partial SoC architecture definition allowing the creation of SoC template for further specialisations
+- You can define things before even knowing all their requirements, ex : instantiating a interruption controller, before knowing how many lines of interrupt you need
+- Abstract/lazy/partial SoC architecture definition allowing the creation of SoC template for further specializations
 - Automatic requirements negotiation between multiple agents in a decentralized way, ex : between masters and slaves of a memory bus
 
 The framework is mainly composed of : 
@@ -22,7 +22,7 @@ The framework is mainly composed of :
 - Handle[T], which allow to refer about something, as for example the result of a generator, before this thing even exist
 
 
-Warning, this is realy not usual RTL description and aim large system generation.
+Warning, this is really not usual RTL description and aim large system generation.
 
 Simple dummy example
 --------------------
@@ -33,20 +33,20 @@ There is a simple example which define two Handle[Int] (a,b) and when loaded, wi
 
   import spinal.lib.generator._
 
-  class Root() extends Generator{
+  class Root() extends Generator {
     //Define some Handle which will be later loaded with real values
     val a,b = Handle[Int]
 
     //Print a + b
-    val calculator = new Generator{
+    val calculator = new Generator {
       //Specify that this generator need a and b before executing his tasks
       dependencies += a
       dependencies += b
 
       //Create a new task that will run when all the dependencies are loaded
-      add task{
+      add task {
         val sum = a.get + b.get
-        println(s"a + b = $sum") //Will print a + b = 7
+        println(s"a + b = $sum") // Will print a + b = 7
       }
     }
 
@@ -63,12 +63,12 @@ Then you can also chain generators via their handles. For instance we could add 
 .. code-block:: scala
 
     //Generate a signal of signalWidth bits
-    val rtl = new Generator{
+    val rtl = new Generator {
       dependencies += signalWidth
 
       val signal = Handle[UInt]
-      add task{
-        println(s"rtlSignal will have ${signalWidth.get} bits") //Will print "rtlSignal will have 7 bits"
+      add task {
+        println(s"rtlSignal will have ${signalWidth.get} bits") // Will print "rtlSignal will have 7 bits"
         signal.load(UInt(signalWidth.get bits))
       }
     }
@@ -76,7 +76,7 @@ Then you can also chain generators via their handles. For instance we could add 
 
 
 Handle[T]
---------------------
+---------
 
 Handle[T] are a bit like scala's Future[T], they allow to talk about something before it is even existing, and wait on it.
 
@@ -89,7 +89,7 @@ Handle[T] are a bit like scala's Future[T], they allow to talk about something b
     x.load(3) //x will now contain the value 3
 
 Generator
---------------------
+---------
 
 
 A Generator is composed of : 
@@ -99,54 +99,54 @@ A Generator is composed of :
 - products : List of Handles which are loaded by the generator's tasks
 
 dependencies
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^
 
 There is multiple ways to add/create new dependencies : 
 
 .. code-block:: scala
 
-  class MyGenerator() extends Generator{
+  class MyGenerator() extends Generator {
     dependencies += somebodyElseHandle
 
-    val myHandle : Handle[Int] = createDependency[Int] //Create a unloaded Handle[Int]
+    val myHandle : Handle[Int] = createDependency[Int] // Create a unloaded Handle[Int]
   }
 
 
 tasks
-^^^^^^^^^^^^^^^^^^^^
+^^^^^
 
 .. code-block:: scala
 
-  class MyGenerator() extends Generator{
+  class MyGenerator() extends Generator {
     val width = createDependency[Int]
-    val logic = add task new Area{
+    val logic = add task new Area {
       val a,b,c = UInt(width.get bits)
       val result = a + b + c
     }
   }
 
 products
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^
 
 Telling the generator all your products isn't mandatory but help debugging. 
 
 
 .. code-block:: scala
 
-  //At a low level API :
-  class MyGenerator() extends Generator{
+  // At a low level API :
+  class MyGenerator() extends Generator {
     val interface = Handle[Apb3]
     products += interface
-    val rtl = add task new Area{
+    val rtl = add task new Area {
       val bus = Apb3(32,32)
       interface.load(bus)
     }
   }
   
-  //The same but less verbose
-  class MyGenerator() extends Generator{
+  // The same but less verbose
+  class MyGenerator() extends Generator {
     val interface = this.produce(rtl.bus)
-    val rtl = add task new Area{
+    val rtl = add task new Area {
       val bus = Apb3(32,32)
     }
   }

--- a/source/SpinalHDL/Libraries/index.rst
+++ b/source/SpinalHDL/Libraries/index.rst
@@ -11,7 +11,7 @@ The spinal.lib package goals are :
 * Provide some bus definition (Avalon, AMBA, ..)
 * Provide some methodology (Stream, Flow, Fragment)
 * Provide some example to get the spirit of spinal
-* Provide some tools and facilities (latency analyser, QSys converter, ...)
+* Provide some tools and facilities (latency analyzer, QSys converter, ...)
 
 To use features introduced in followings chapter you need, in most of cases, to ``import spinal.lib._`` in your sources.
 

--- a/source/SpinalHDL/Libraries/regIf.rst
+++ b/source/SpinalHDL/Libraries/regIf.rst
@@ -36,7 +36,7 @@ Automatic address allocation
 
 .. image:: /asset/image/regif/reg-auto-allocate.gif
 
-Automatic fileds allocation
+Automatic filed allocation
 
 .. code:: scala
 
@@ -45,9 +45,9 @@ Automatic fileds allocation
   M_REG0.reserved(5 bits)
   val fd1 = M_REG0.field(Bits(3 bit), RW, doc= "fields 0")
   val fd2 = M_REG0.field(Bits(3 bit), RW, doc= "fields 0")
-  //auto reserved 2 bits
+  // auto reserved 2 bits
   val fd3 = M_REG0.fieldAt(pos=16, Bits(4 bit), doc= "fields 3")
-  //auto reserved 12 bits
+  // auto reserved 12 bits
 
 .. image:: /asset/image/regif/field-auto-allocate.gif
 
@@ -159,7 +159,7 @@ Attention, please don't forget to drive it.
 
 .. code:: scala
 
-   val overflow = M_REG0.field(Bits(32 bit), RO, 0, "xx-ip paramete")
+   val overflow = M_REG0.field(Bits(32 bit), RO, 0, "xx-ip parameter")
    val ovfreg = Reg(32 bit)
    overflow := ovfreg
    
@@ -167,9 +167,9 @@ Attention, please don't forget to drive it.
 .. code:: scala
 
    val inc    = in Bool()
-   val couter = M_REG0.field(UInt(8 bit), RO, 0, "counter")
+   val counter = M_REG0.field(UInt(8 bit), RO, 0, "counter")
    val cnt = Counter(100,  inc)
-   couter := cnt
+   counter := cnt
 
       
 **CASE2:** ``ROV`` usage
@@ -201,8 +201,8 @@ In some cases, such registers are not only configured by software, but also set 
      val xxx_set_val = in Bits(32 bit)
    }
 
-   val reg0 = M_REG0.fieldHSRW(io.xxx_set, io.xxx_set_val, 0, "xx-device version")  //0x0000
-   val reg1 = M_REG1.fieldRWHS(io.xxx_set, io.xxx_set_val, 0, "xx-device version")  //0x0004
+   val reg0 = M_REG0.fieldHSRW(io.xxx_set, io.xxx_set_val, 0, "xx-device version")  // 0x0000
+   val reg1 = M_REG1.fieldRWHS(io.xxx_set, io.xxx_set_val, 0, "xx-device version")  // 0x0004
 
 .. code:: verilog
 
@@ -214,14 +214,14 @@ In some cases, such registers are not only configured by software, but also set 
         if(hit_0x0000) begin
            reg0 <= wdata ;
         end
-        if(io.xxx_set) begin      //HW have High priority than SW
+        if(io.xxx_set) begin      // HW have High priority than SW
            reg0 <= io.xxx_set_val ;
         end
 
         if(io.xxx_set) begin
            reg1 <= io.xxx_set_val ;
         end 
-        if(hit_0x0004) begin      //SW have High priority than HW
+        if(hit_0x0004) begin      // SW have High priority than HW
            reg1 <= wdata ;
         end
      end
@@ -251,15 +251,15 @@ example1: clock gate software enable
 
 .. code:: scala
 
-   val M_CG_ENS_SET = busif.newReg(doc="Clock Gate Enables")  //0x0000
-   val M_CG_ENS_CLR = busif.newReg(doc="Clock Gate Enables")  //0x0004
-   val M_CG_ENS_RO  = busif.newReg(doc="Clock Gate Enables")  //0x0008
+   val M_CG_ENS_SET = busif.newReg(doc="Clock Gate Enables")  // x00000
+   val M_CG_ENS_CLR = busif.newReg(doc="Clock Gate Enables")  // 0x0004
+   val M_CG_ENS_RO  = busif.newReg(doc="Clock Gate Enables")  // 0x0008
 
-   val xx_sys_cg_en = M_CG_ENS_SET.field(Bits(4 bit), W1S, 0, "clock gate enalbes, write 1 set" ) 
-                      M_CG_ENS_CLR.parasiteField(xx_sys_cg_en, W1C, 0, "clock gate enalbes, write 1 clear" ) 
+   val xx_sys_cg_en = M_CG_ENS_SET.field(Bits(4 bit), W1S, 0, "clock gate enables, write 1 set" ) 
+                      M_CG_ENS_CLR.parasiteField(xx_sys_cg_en, W1C, 0, "clock gate enables, write 1 clear" ) 
                       M_CG_ENS_RO.parasiteField(xx_sys_cg_en, RO, 0, "clock gate enables, read only"
 
-example2: interrupt raw reg with foce interface for software
+example2: interrupt raw reg with force interface for software
 
 .. code:: scala
 
@@ -306,7 +306,7 @@ Batch create REG-Address and fields register
     val busif = Apb3BusInterface(io.apb, (0x000, 100 Byte), regPre = "AP")
 
     (0 to 9).map { i =>
-      //here use setName give REG uniq name for Docs usage
+      // here use setName give REG uniq name for Docs usage
       val REG = busif.newReg(doc = s"Register${i}").setName(s"REG${i}")
       val real = REG.field(SInt(8 bit), AccessType.RW, 0, "Complex real")
       val imag = REG.field(SInt(8 bit), AccessType.RW, 0, "Complex imag")
@@ -411,7 +411,7 @@ Register   AccessType  Description
 ========== ==========  ======================================================================
 RAW        W1C         int raw register, set by int event, clear when bus write 1  
 FORCE      RW          int force register, for SW debug use 
-MASK       RW          int mask register, 1: off; 0: open; defualt 1 int off 
+MASK       RW          int mask register, 1: off; 0: open; default 1 int off 
 STATUS     RO          int status, Read Only, ``status = raw && ! mask``                 
 ========== ==========  ======================================================================
  
@@ -430,7 +430,7 @@ SYS level interrupt merge
 ========== ==========  ======================================================================
 Register   AccessType  Description                                                           
 ========== ==========  ======================================================================
-MASK       RW          int mask register, 1: off; 0: open; defualt 1 int off 
+MASK       RW          int mask register, 1: off; 0: open; default 1 int off 
 STATUS     RO          int status, RO, ``status = int_level && ! mask``                 
 ========== ==========  ======================================================================
 
@@ -454,8 +454,8 @@ BusInterface method                                                             
 ``InterruptFactoryAt(addrOffset: Int, regNamePre: String, triggers: Bool*)``                  create RAW/FORCE/MASK/STATUS for pulse event at addrOffset 
 ``InterruptFactoryNoForceAt(addrOffset: Int, regNamePre: String, triggers: Bool*)``           create RAW/MASK/STATUS for pulse event at addrOffset     
 ``InterruptFactoryAt(addrOffset: Int, regNamePre: String, triggers: Bool*)``                  create MASK/STATUS for level_int merge at addrOffset      
-``interrupt_W1SCmask_FactoryAt(addrOffset: BigInt, regNamePre: String, triggers: Bool*)``     creat RAW/FORCE/MASK(SET/CLR)/STATUS for pulse event at addrOffset
-``interruptLevel_W1SCmask_FactoryAt(addrOffset: BigInt, regNamePre: String, levels: Bool*)``  creat RAW/FORCE/MASK(SET/CLR)/STATUS for leveel event at addrOffset
+``interrupt_W1SCmask_FactoryAt(addrOffset: BigInt, regNamePre: String, triggers: Bool*)``     create RAW/FORCE/MASK(SET/CLR)/STATUS for pulse event at addrOffset
+``interruptLevel_W1SCmask_FactoryAt(addrOffset: BigInt, regNamePre: String, levels: Bool*)``  create RAW/FORCE/MASK(SET/CLR)/STATUS for level event at addrOffset
 ============================================================================================= ===================================================================
                                
 Example
@@ -478,7 +478,7 @@ Example
 
       def genDoc() = {
         busif.accept(CHeaderGenerator("intrreg","Intr"))
-        busif.accept(HtmlGenerator("intrreg", "Interupt Example"))
+        busif.accept(HtmlGenerator("intrreg", "Interrupt Example"))
         busif.accept(JsonGenerator("intrreg"))
         busif.accept(RalfGenerator("intrreg"))
         busif.accept(SystemRdlGenerator("intrreg", "Intr"))
@@ -513,15 +513,15 @@ In order to facilitate software debugging, the read back value can be configured
 Developers Area
 ===============
 
-You can add your document Type by extending the `BusIfVistor` Trait 
+You can add your document Type by extending the `BusIfVisitor` Trait 
 
 ``case class Latex(fileName : String) extends BusIfVisitor{ ... }``
 
-BusIfVistor give access BusIf.RegInsts to do what you want 
+BusIfVisitor give access BusIf.RegInsts to do what you want 
 
 .. code:: scala
 
-    // lib/src/main/scala/lib/bus/regif/BusIfVistor.scala 
+    // lib/src/main/scala/spinal/lib/bus/regif/BusIfBase.scala
 
     trait BusIfVisitor {
       def begin(busDataWidth : Int) : Unit

--- a/source/SpinalHDL/Libraries/stream.rst
+++ b/source/SpinalHDL/Libraries/stream.rst
@@ -79,7 +79,7 @@ Semantics
 
 When manually reading/driving the signals of a Stream keep in mind that:
 
-* After being asserted, ``valid`` may only be deasserted once the current payload was acknowleged. This means ``valid`` can only toggle to 0 the cycle after a the slave did a read by asserting ``ready``.
+* After being asserted, ``valid`` may only be deasserted once the current payload was acknowledged. This means ``valid`` can only toggle to 0 the cycle after a the slave did a read by asserting ``ready``.
 * In contrast to that ``ready`` may change at any time. 
 * A transfer is only done on cycles where both ``valid`` and ``ready`` are asserted.
 * ``valid`` of a Stream must not depend on ``ready`` in a combinatorial way and any path between the two must be registered.
@@ -119,19 +119,19 @@ Functions
      - 2
    * - | x.m2sPipe()
        | x.stage()
-     - | Return a Stream drived by x
+     - | Return a Stream driven by x
        | through a register stage that cut valid/payload paths
        | Cost = (payload width + 1) flop flop
      - Stream[T]
      - 1
    * - x.s2mPipe()
-     - | Return a Stream drived by x
+     - | Return a Stream driven by x
        | ready paths is cut by a register stage
        | Cost = payload width * (mux2 + 1 flip flop)
      - Stream[T]
      - 0
    * - x.halfPipe()
-     - | Return a Stream drived by x
+     - | Return a Stream driven by x
        | valid/ready/payload paths are cut by some register
        | Cost = (payload width + 2) flip flop, bandwidth divided by two
      - Stream[T]
@@ -211,7 +211,7 @@ On each stream you can call the .queue(size) to get a buffered stream. But you c
 .. code-block:: scala
 
    val streamA,streamB = Stream(Bits(8 bits))
-   //...
+   // ...
    val myFifo = StreamFifo(
      dataType = Bits(8 bits),
      depth    = 128
@@ -265,7 +265,7 @@ You can instantiate the dual clock domain version of the fifo the following way 
    val clockA = ClockDomain(???)
    val clockB = ClockDomain(???)
    val streamA,streamB = Stream(Bits(8 bits))
-   //...
+   // ...
    val myFifo = StreamFifoCC(
      dataType  = Bits(8 bits),
      depth     = 128,
@@ -328,7 +328,7 @@ StreamCCByToggle
    val clockA = ClockDomain(???)
    val clockB = ClockDomain(???)
    val streamA,streamB = Stream(Bits(8 bits))
-   //...
+   // ...
    val bridge = StreamCCByToggle(
      dataType    = Bits(8 bits),
      inputClock  = clockA,
@@ -436,7 +436,7 @@ When you have multiple Streams and you want to arbitrate them to drive a single 
    * - roundRobin
      - Fair round robin arbitration
    * - sequentialOrder
-     - | Could be used to retrieve transaction in a sequancial order
+     - | Could be used to retrieve transaction in a sequential order
        | First transaction should come from port zero, then from port one, ...
 
 
@@ -596,7 +596,7 @@ For simulation master and slave implementations are available:
     - Used for both master and slave sides, calls function with payload if Stream fires.
   * - StreamDriver
     - Testbench master side, drives values by calling function to apply value (if available). Function must return if value was available. Supports random delays.
-  * - StreamReadyRandmizer
+  * - StreamReadyRandomizer
     - Randomizes ``ready`` for reception of data, testbench is the slave side.
   * - ScoreboardInOrder
     - Often used to compare reference/dut data

--- a/source/SpinalHDL/Libraries/utils.rst
+++ b/source/SpinalHDL/Libraries/utils.rst
@@ -163,7 +163,7 @@ The Timeout tool can be used to easily instantiate an hardware timeout.
    :header-rows: 1
    :widths: 1 1
 
-   * - Instanciation syntax
+   * - Instantiation syntax
      - Notes
    * - Timeout(cycles : BigInt)
      - Tick after ``cycles`` clocks
@@ -177,9 +177,9 @@ There is an example of different syntaxes which could be used with the Counter t
 
 .. code-block:: scala
 
-   val timeout = Timeout(10 ms)  //Timeout who tick after 10 ms
-   when(timeout) {               //Check if the timeout has tick
-       timeout.clear()           //Ask the timeout to clear its flag
+   val timeout = Timeout(10 ms)  // Timeout who tick after 10 ms
+   when(timeout) {               // Check if the timeout has tick
+       timeout.clear()           // Ask the timeout to clear its flag
    }
 
 .. note::
@@ -193,7 +193,7 @@ The ResetCtrl provide some utilities to manage resets.
 asyncAssertSyncDeassert
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-You can filter an asynchronous reset by using an asynchronously asserted synchronously deaserted logic. To do it you can use the ``ResetCtrl.asyncAssertSyncDeassert`` function which will return you the filtered value.
+You can filter an asynchronous reset by using an asynchronously asserted synchronously deasserted logic. To do it you can use the ``ResetCtrl.asyncAssertSyncDeassert`` function which will return you the filtered value.
 
 .. list-table::
    :header-rows: 1

--- a/source/SpinalHDL/Other language features/analog_inout.rst
+++ b/source/SpinalHDL/Other language features/analog_inout.rst
@@ -68,7 +68,7 @@ For instance:
 .. code-block:: scala
 
    case class Apb3Gpio(gpioWidth : Int) extends Component {
-     val io = new Bundle{
+     val io = new Bundle {
        val gpio = master(TriStateArray(gpioWidth bits))
        val apb  = slave(Apb3(Apb3Gpio.getApb3Config()))
      }

--- a/source/SpinalHDL/Other language features/report.rst
+++ b/source/SpinalHDL/Other language features/report.rst
@@ -6,7 +6,7 @@ You can add debugging in RTL for simulation, using the following syntax:
 
 .. code-block:: scala
 
-    object Enum extends SpinalEnum{
+    object Enum extends SpinalEnum {
         val MIAOU, RAWRR = newElement()
     }
 

--- a/source/SpinalHDL/Other language features/scope_property.rst
+++ b/source/SpinalHDL/Other language features/scope_property.rst
@@ -7,7 +7,7 @@ A scope property is a thing which can store values locally to the current thread
 
 In other words it is a alternative to global variable, scala implicit, ThreadLocal.
 
-* To compare with global variable, It allow to run multiple thread running the same code indepedently
+* To compare with global variable, It allow to run multiple thread running the same code independently
 * To compare with scala implicit, it is less intrusive in the code base
 * To compare with ThreadLocal, it has some API to collect all ScopeProperty and restore them in the same state later on
 
@@ -18,15 +18,15 @@ In other words it is a alternative to global variable, scala implicit, ThreadLoc
 
   object ScopePropertyMiaou extends App {
     Xlen.set(1)
-    println(Xlen.get) //1
+    println(Xlen.get) // 1
     Xlen(2) {
-      println(Xlen.get) //2
+      println(Xlen.get) // 2
       Xlen(3) {
-        println(Xlen.get) //3
+        println(Xlen.get) // 3
         Xlen.set(4)
-        println(Xlen.get) //4
+        println(Xlen.get) // 4
       }
-      println(Xlen.get) //2
+      println(Xlen.get) // 2
     }
   }
 

--- a/source/SpinalHDL/Other language features/stub.rst
+++ b/source/SpinalHDL/Other language features/stub.rst
@@ -1,6 +1,6 @@
 
 Stub
-======
+====
 
 You can empty an Component Hierarchy as stub:
 
@@ -14,7 +14,7 @@ You can empty an Component Hierarchy as stub:
        io.dy <-< io.dx
     }
     class TopLevel extends Component {
-       val dut = new SubSysModule().stub   //instance an SubSysModule as empty stub
+       val dut = new SubSysModule().stub   // instance an SubSysModule as empty stub
     }
    
 It will generate the following Verilog code for example:
@@ -50,7 +50,7 @@ What does `stub` do ?
 
 * first walk all the components and find out clock, then keep clock 
 * then remove all children component
-* then remove all assignment and logic we dont want 
+* then remove all assignment and logic we don't want 
 * tile 0 to output port
 
 

--- a/source/SpinalHDL/Semantic/assignments.rst
+++ b/source/SpinalHDL/Semantic/assignments.rst
@@ -20,7 +20,7 @@ When muxing (for instance using ``when``, see :doc:`when_switch`.), the last
 valid standard assignment ``:=`` wins. Else, assigning twice to the same assignee
 from the same scope results in an assignment overlap.  SpinalHDL will assume
 this is a unintentional design error by default and halt elaboration with error.
-For special use-cases assignment overlap can be programatically permitted on a case by case basis.
+For special use-cases assignment overlap can be programmatically permitted on a case by case basis.
 (see :doc:`../Design errors/assignment_overlap`).
 
 .. code-block:: scala
@@ -28,8 +28,8 @@ For special use-cases assignment overlap can be programatically permitted on a c
    val a, b, c = UInt(4 bits)
    a := 0
    b := a
-   //a := 1 // this would cause an `assignment overlap` error,
-            // if manually overridden the assignment would take assignment priority
+   // a := 1 // this would cause an `assignment overlap` error,
+             // if manually overridden the assignment would take assignment priority
    c := a
 
    var x = UInt(4 bits)
@@ -179,5 +179,5 @@ If we look at the resulting Verilog, ``b`` is not present. Since it is a copy of
     }
 
 Without ``CombInit``, if ``c`` == false (but not if ``c`` == true), ``a1`` and ``a2`` reference the same signal and the zero assignment is also applied to ``a1``.
-With ``CombInit`` we have a coherent behaviour whatever the ``c`` value.
+With ``CombInit`` we have a coherent behavior whatever the ``c`` value.
 

--- a/source/SpinalHDL/Semantic/rules.rst
+++ b/source/SpinalHDL/Semantic/rules.rst
@@ -45,14 +45,14 @@ use of the SpinalHDL ``:=`` operator, the last assignment that may execute wins
 
 It could be said that top to bottom evaluation occurs based on the state that
 exists at that time.  If your upstream signal inputs are driven from registers
-and so have synchronous behaviour, then it could be said that at each clock
+and so have synchronous behavior, then it could be said that at each clock
 cycle the assignments are re-evaluated based on the new state at the time.
 
 Some reasons why an assignment statement may not get to execute in hardware this
 clock cycle, maybe due to it being wrapped in a ``when(cond)`` clause.
 
 Another reason maybe that the SpinalHDL code never made it through elaboration
-because the feature was paramaterized and disabled during HDL code-generation,
+because the feature was parameterized and disabled during HDL code-generation,
 see ``paramIsFalse`` use below.
 
 As an example:

--- a/source/SpinalHDL/Semantic/when_switch.rst
+++ b/source/SpinalHDL/Semantic/when_switch.rst
@@ -61,7 +61,7 @@ Therefore, we provide a 'whenBuilder' method to achieve this goal
     ctx.when(conds(1)) {
       result := 1
     }
-    if(true){
+    if(true) {
       ctx.when(conds(2)) {
         result := 2
       }
@@ -79,7 +79,7 @@ we can also use like this
       result := i
     }
 
-    ctx.otherwise{
+    ctx.otherwise {
       result := 255
     }
 
@@ -287,7 +287,7 @@ Below is an example of dividing a ``Bits`` of 128 bits into 32 bits:
    val dataWord = sel.muxList(for (index <- 0 until 4)
                               yield (index, data(index*32+32-1 downto index*32)))
 
-   // A shorter way to do the same thing:
+   // A shorter way to do the same thing:
    val dataWord = data.subdivideIn(32 bits)(sel)
 
 Example for ``muxListDc`` selecting bits from a configurable width vector:

--- a/source/SpinalHDL/Sequential logic/memory.rst
+++ b/source/SpinalHDL/Sequential logic/memory.rst
@@ -115,7 +115,7 @@ When enable signals are used in a block guarded by a conditional block like `whe
 .. code-block:: scala
 
     val rom = Mem(Bits(10 bits), 32)
-    when(cond){
+    when(cond) {
       io.rdata := rom.readSync(io.addr, io.rdEna)
     }
 

--- a/source/SpinalHDL/Sequential logic/registers.rst
+++ b/source/SpinalHDL/Sequential logic/registers.rst
@@ -136,7 +136,7 @@ If you have a register containing a Bundle, you can use the ``init`` function on
 
 .. code-block:: scala
 
-   case class ValidRGB() extends Bundle{
+   case class ValidRGB() extends Bundle {
      val valid   = Bool()
      val r, g, b = UInt(8 bits)
    }
@@ -200,7 +200,7 @@ In case where the initialization must be deferred since the init value is not kn
    }
 
    class SRConsumer() extends Component {
-      //...
+      // ...
       val sr = ShiftRegister(Flow(UInt(8 bits)), 4, SRConsumer.initIdleFlow[UInt])
    }
 

--- a/source/SpinalHDL/Simulation/bootstraps.rst
+++ b/source/SpinalHDL/Simulation/bootstraps.rst
@@ -162,7 +162,7 @@ The location where the simulation files will be placed is defined by default in 
 - $COMPILED being the name of the toplevel being simulated.
 - The location of the wave file depend the backend used. For verilator it will be in the folder (``$WORKSPACE/$COMPILED/$TEST`` by default). 
 - For the verilator backend, you can override the location of the test folder via the ``SimConfig.setTestPath(path)`` function.
-- You can retrieve the location of the test path durring simulation by calling the currentTestPath() function.
+- You can retrieve the location of the test path during simulation by calling the currentTestPath() function.
 
 
 Running multiple tests on the same hardware

--- a/source/SpinalHDL/Simulation/clock.rst
+++ b/source/SpinalHDL/Simulation/clock.rst
@@ -1,8 +1,8 @@
 Clock domains 
-==========================================
+=============
 
 Stimulus API
-----------------------------------
+------------
 
 Below is a list of ``ClockDomain`` stimulation functions:
 
@@ -36,7 +36,7 @@ Below is a list of ``ClockDomain`` stimulation functions:
      - Set the softReset signal to its active level
 
 Wait API
-----------------------------------
+--------
 
 Below is a list of ``ClockDomain`` utilities that you can use to wait for a given event from the domain:
 
@@ -72,7 +72,7 @@ Below is a list of ``ClockDomain`` utilities that you can use to wait for a give
 .. _sim_clock_threadless:
 
 Callback API
-----------------------------------
+------------
 
 Below is a list of ``ClockDomain`` utilities that you can use to wait for a given event from the domain:
 
@@ -96,11 +96,10 @@ Below is a list of ``ClockDomain`` utilities that you can use to wait for a give
      - Execute the callback code each time the ``ClockDomain`` clock generates a falling edge
    * - ``onSamplingWhile { callback : Boolean }``
      - Same as onSampling, but you can stop it (forever) by letting the callback returning false
-     
 
 
 Default ClockDomain
-----------------------------------
+-------------------
 
 You can access the default ``ClockDomain`` of your toplevel as shown below:
 
@@ -132,7 +131,7 @@ An example of how to wait for a rising edge on the clock:
 
 
 New ClockDomain
---------------------------------
+---------------
 
 If your toplevel defines some clock and reset inputs which aren't directly integrated into their ``ClockDomain``, you can define their corresponding ``ClockDomain`` directly in the testbench:
 

--- a/source/SpinalHDL/Simulation/engine.rst
+++ b/source/SpinalHDL/Simulation/engine.rst
@@ -1,8 +1,8 @@
 
 
-========================
+=================
 Simulation engine
-========================
+=================
 
 This page explains the internals of the simulation engine. 
 

--- a/source/SpinalHDL/Simulation/examples/asynchronous.rst
+++ b/source/SpinalHDL/Simulation/examples/asynchronous.rst
@@ -32,7 +32,7 @@ The test bench performs the following steps 100 times:
      def main(args: Array[String]): Unit = {
        SimConfig.withWave.compile(new Dut).doSim{ dut =>
          var idx = 0
-         while(idx < 100){
+         while(idx < 100) {
            val a, b, c = Random.nextInt(256)
            dut.io.a #= a
            dut.io.b #= b

--- a/source/SpinalHDL/Simulation/examples/synchronous.rst
+++ b/source/SpinalHDL/Simulation/examples/synchronous.rst
@@ -36,7 +36,7 @@ The main difference between this example and the :ref:`Asynchronous adder <sim_e
          dut.clockDomain.forkStimulus(period = 10)
 
          var resultModel = 0
-         for(idx <- 0 until 100){
+         for(idx <- 0 until 100) {
            dut.io.a #= Random.nextInt(256)
            dut.io.b #= Random.nextInt(256)
            dut.io.c #= Random.nextInt(256)

--- a/source/SpinalHDL/Simulation/examples/uart_encoder.rst
+++ b/source/SpinalHDL/Simulation/examples/uart_encoder.rst
@@ -5,7 +5,7 @@ Uart encoder
 .. code-block:: scala
 
      // Fork a simulation process which will get chars typed into the simulation terminal and transmit them on the simulation uartPin.
-     fork{
+     fork {
        uartPin #= true
        while(true) {
          // System.in is the java equivalent of the C's stdin.

--- a/source/SpinalHDL/Simulation/install/Icarus Verilog.rst
+++ b/source/SpinalHDL/Simulation/install/Icarus Verilog.rst
@@ -18,5 +18,5 @@ Linux
 
 
 Also the openjdk package that corresponds to your Java version has to be installed.
-Refer to `<https://iverilog.fandom.com/wiki/Installation_Guide>`_ for more informations about Windows and installation from source.
+Refer to `<https://iverilog.fandom.com/wiki/Installation_Guide>`_ for more information about Windows and installation from source.
 

--- a/source/SpinalHDL/Simulation/install/VCS.rst
+++ b/source/SpinalHDL/Simulation/install/VCS.rst
@@ -122,7 +122,7 @@ Also, you can control the wave trace depth by using ``withWaveDepth(depth: Int)`
 Simulation with ``Blackbox``
 ----------------------------
 
-Sometimes, IP vendors will provide you with some design entites in Verilog/VHDL format and you want to integrate them into your SpinalHDL design. 
+Sometimes, IP vendors will provide you with some design entities in Verilog/VHDL format and you want to integrate them into your SpinalHDL design. 
 The integration can done by following two ways:
 
 1. In a ``Blackbox`` definition, use ``addRTLPath(path: String)`` to assign a external Verilog/VHDL file to this blackbox.

--- a/source/SpinalHDL/Simulation/install/Verilator.rst
+++ b/source/SpinalHDL/Simulation/install/Verilator.rst
@@ -114,5 +114,5 @@ From source
    Be sure that your ``PATH`` environnement variable is pointing to the JDK 1.8 and doesn't contain a JRE installation.
 
 .. important::
-   Adding the MSYS2 ``bin`` folders into your windows ``PATH`` could potentialy have some side effects.
+   Adding the MSYS2 ``bin`` folders into your windows ``PATH`` could potentially have some side effects.
    This is why it is safer to add them as the last elements of the ``PATH`` to reduce their priority.

--- a/source/SpinalHDL/Simulation/sensitive.rst
+++ b/source/SpinalHDL/Simulation/sensitive.rst
@@ -1,7 +1,7 @@
 .. _sim_sensitive_api:
 
 Sensitive API
-==========================================
+=============
 
 You can register callback functions to be called on each delta-cycle of the simulation:
 

--- a/source/SpinalHDL/Simulation/signal.rst
+++ b/source/SpinalHDL/Simulation/signal.rst
@@ -1,5 +1,5 @@
 Accessing signals of the simulation
-==========================================
+===================================
 
 Read and write signals
 ----------------------

--- a/source/SpinalHDL/Simulation/threadFull.rst
+++ b/source/SpinalHDL/Simulation/threadFull.rst
@@ -1,5 +1,5 @@
 Thread-full API
-==========================================
+===============
 
 In SpinalSim, you can write your testbench by using multiple threads in a similar way to SystemVerilog, and a bit like VHDL/Verilog process/always blocks. 
 This allows you to write concurrent tasks and control the simulation time using a fluent API.

--- a/source/SpinalHDL/Simulation/threadLess.rst
+++ b/source/SpinalHDL/Simulation/threadLess.rst
@@ -1,5 +1,5 @@
 Thread-less API
-==========================================
+===============
 
 There are some functions that you can use to avoid the need for threading, but which still allow you to control the flow of simulation time.
 

--- a/source/SpinalHDL/Structuring/blackbox.rst
+++ b/source/SpinalHDL/Structuring/blackbox.rst
@@ -168,7 +168,7 @@ By default the ports of the blackbox are considered clock-less, meaning no clock
 .. code-block:: scala
 
     class DemoBlackbox extends BlackBox {
-      val io = new Bundle{
+      val io = new Bundle {
         val clk, rst = in Bool()
         val a = in Bool()
         val b = out Bool()
@@ -249,13 +249,13 @@ This function takes a no-argument function to be applied during compilation, and
 
      val io = new Bundle {
        val clk = in Bool()
-       val portA = new Bundle{
+       val portA = new Bundle {
          val cs   = in Bool()
          val rwn  = in Bool()
          val dIn  = in Bits(32 bits)
          val dOut = out Bits(32 bits)
        }
-       val portB = new Bundle{
+       val portB = new Bundle {
          val cs   = in Bool()
          val rwn  = in Bool()
          val dIn  = in Bits(32 bits)
@@ -312,15 +312,15 @@ With the function ``addRTLPath()`` you can associate your RTL sources with the 
      // Add all rtl dependencies
      addRTLPath("./rtl/RegisterBank.v")                         // Add a verilog file 
      addRTLPath(s"./rtl/myDesign.vhd")                          // Add a vhdl file 
-     addRTLPath(s"${sys.env("MY_PROJECT")}/myTopLevel.vhd")     // Use an environement variable MY_PROJECT (System.getenv("MY_PROJECT"))
+     addRTLPath(s"${sys.env("MY_PROJECT")}/myTopLevel.vhd")     // Use an environment variable MY_PROJECT (System.getenv("MY_PROJECT"))
    }
 
    ...
 
-   class TopLevel() extends Component{
-     //...
+   class TopLevel() extends Component {
+     // ...
      val bb = new MyBlackBox()
-     //...
+     // ...
    }
 
    val report = SpinalVhdl(new TopLevel)
@@ -333,7 +333,7 @@ If you want to use only ``std_logic_vector`` in your blackbox component, you can
 
 .. code-block:: scala
 
-   class MyBlackBox() extends BlackBox{
+   class MyBlackBox() extends BlackBox {
      val io = new Bundle {
        val clk       = in  Bool()
        val increment = in  Bool()

--- a/source/SpinalHDL/Structuring/clock_domain.rst
+++ b/source/SpinalHDL/Structuring/clock_domain.rst
@@ -297,7 +297,7 @@ Signal priorities in HDL generation
 
 In the current version, reset and clock enable signals have different priorities. Their order is : ``asyncReset``, ``clockEnable``, ``syncReset`` and ``softReset``.
 
-Please be careful that clockEnable has a higher priority than syncReset. If you do a sync reset when the clockEnable is disabled (especially at the beginning of a simulation), the gated registers will not be reseted.
+Please be careful that clockEnable has a higher priority than syncReset. If you do a sync reset when the clockEnable is disabled (especially at the beginning of a simulation), the gated registers will not be reset.
 
 Here is an example:
 
@@ -321,7 +321,7 @@ It will generate VerilogHDL codes like:
     end
   end
 
-If that behaviour is problematic, one workaround is to use a when statement as a clock enable instead of using the ClockDomain.enable feature. This is open for future improvements.
+If that behavior is problematic, one workaround is to use a when statement as a clock enable instead of using the ClockDomain.enable feature. This is open for future improvements.
 
 Context
 ^^^^^^^

--- a/source/SpinalHDL/Structuring/components_hierarchy.rst
+++ b/source/SpinalHDL/Structuring/components_hierarchy.rst
@@ -89,7 +89,7 @@ There are some rules to follow with component interconnection:
 Pruned signals
 --------------
 
-SpinalHDL will generate all the named signals and their depedencies, while all the useless anonymous / zero width ones
+SpinalHDL will generate all the named signals and their dependencies, while all the useless anonymous / zero width ones
 are removed from the RTL generation.
 
 You can collect the list of all the removed ans useless signals via the ``printPruned`` and the ``printPrunedIo``
@@ -114,7 +114,7 @@ functions on the generated ``SpinalReport`` object:
    object Main {
      def main(args: Array[String]) {
        SpinalVhdl(new TopLevel).printPruned()
-       //This will report :
+       // This will report :
        //  [Warning] Unused wire detected : toplevel/unusedSignal : UInt[8 bits]
        //  [Warning] Unused wire detected : toplevel/unusedSignal2 : UInt[8 bits]
      }

--- a/source/SpinalHDL/Structuring/index.rst
+++ b/source/SpinalHDL/Structuring/index.rst
@@ -7,7 +7,7 @@ The chapters below explain:
 - how to build reusable components
 - alternatives to components to group hardware
 - handling of clock/reset domains
-- instantitation of existing VHDL and Verilog IP
+- instantiation of existing VHDL and Verilog IP
 - how names are assigned in SpinalHDL, and how naming can be influenced
 
 .. toctree::

--- a/source/SpinalHDL/Structuring/naming.rst
+++ b/source/SpinalHDL/Structuring/naming.rst
@@ -1,10 +1,10 @@
 Preserving names
-==================
+================
 
 This page will describe how SpinalHDL propagate names from the scala code to the generated hardware. Knowing them should enable you to preserve those names as much as possible to generate understandable netlists.
 
 Nameable base class
-------------------------------------------
+-------------------
 
 All the things which can be named in SpinalHDL extends the Nameable base class which.
 
@@ -38,10 +38,10 @@ Will generation :
       wire                rawrr_wuff;
     endmodule
 
-In general, you don't realy need to access that API, unless you want to do tricky stuff for debug reasons or for elaboration purposes.
+In general, you don't really need to access that API, unless you want to do tricky stuff for debug reasons or for elaboration purposes.
 
 Name extraction from Scala
-------------------------------------------
+--------------------------
 
 First, since version 1.4.0, SpinalHDL use a scala compiler plugin which can provide a call back each time a new val is defined during the construction of an class.
 
@@ -49,7 +49,7 @@ There is a example showing more or less how SpinalHDL itself is implemented :
 
 .. code-block:: scala
 
-    //spinal.idslplugin.ValCallback is the Scala compiler plugin feature which will provide the callbacks
+    // spinal.idslplugin.ValCallback is the Scala compiler plugin feature which will provide the callbacks
     class Component extends spinal.idslplugin.ValCallback {
       override def valCallback[T](ref: T, name: String) : T = {
         println(s"Got $ref named $name") // Here we just print what we got as a demo.
@@ -106,13 +106,13 @@ Will generate :
       output     [7:0]    toto
     );
       // Note that the tmp signal defined in scala was "shortcuted" by SpinalHDL,
-      //  as it was unamed and technicaly "shortcutable"
+      //  as it was unnamed and technically "shortcutable"
       assign toto = 8'h20;
     endmodule
 
 
 Area in a Component
---------------------
+-------------------
 
 One important aspect in the naming system is that you can define new namespaces inside components and manipulate
 
@@ -142,7 +142,7 @@ Will generate
     endmodule
 
 Area in a function
---------------------
+------------------
 
 You can also define function which will create new Area which will provide a namespace for all its content :
 
@@ -183,7 +183,7 @@ Added in SpinalHDL 1.5.0, Composite which allow you to create a scope which will
 .. code-block:: scala
 
   class MyComponent extends Component {
-    // Basicaly, a Composite is an Area that use its construction parameter as namespace prefix
+    // Basically, a Composite is an Area that use its construction parameter as namespace prefix
     def isZero(value: UInt) = new Composite(value) {
       val comparator = value === 0
     }.comparator  // Note we don't return the Composite,
@@ -210,7 +210,7 @@ Will generate :
     endmodule
 
 Composite chains
-----------------------------
+----------------
 
 You can also chain composites :
 
@@ -249,10 +249,10 @@ Will generate :
     endmodule
 
 Composite in a Bundle's function
-------------------------------------
+--------------------------------
 
 
-This behaviour can be very useful when implementing Bundle utilities. For instance in the spinal.lib.Stream class is defined the following :
+This behavior can be very useful when implementing Bundle utilities. For instance in the spinal.lib.Stream class is defined the following :
 
 .. code-block:: scala
 
@@ -359,19 +359,19 @@ Will generate
     endmodule
 
 
-Unamed signal handling
-----------------------------------------
+Unnamed signal handling
+-----------------------
 
-Since 1.5.0, for signal which end up without name, SpinalHDL will find a signal which is driven by that unamed signal and propagate its name. This can produce useful results as long you don't have too large island of unamed stuff.
+Since 1.5.0, for signal which end up without name, SpinalHDL will find a signal which is driven by that unnamed signal and propagate its name. This can produce useful results as long you don't have too large island of unnamed stuff.
 
-The name attributed to such unamed signal is : _zz_ + drivenSignal.getName()
+The name attributed to such unnamed signal is : _zz_ + drivenSignal.getName()
 
 Note that this naming pattern is also used by the generation backend when they need to breakup some specific expressions or long chain of expression into multiple signals.
 
 Verilog expression splitting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is an instance of expressions (ex : the + operator) that SpinalHDL need to express in dedicated signals to match the behaviour with the Scala API :
+There is an instance of expressions (ex : the + operator) that SpinalHDL need to express in dedicated signals to match the behavior with the Scala API :
 
 .. code-block:: scala
 
@@ -401,9 +401,9 @@ Will generate
     endmodule
 
 Verilog long expression splitting
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There is a instance of how a very long expression chain will be splited up by SpinalHDL :
+There is a instance of how a very long expression chain will be split up by SpinalHDL :
 
 .. code-block:: scala
 
@@ -445,13 +445,13 @@ Will generate
     endmodule
 
 When statement condition
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `when(cond) { }` statements condition are generated into separated signals named `when_` + fileName + line. A similar thing will also be done for switch statements.
 
 .. code-block:: scala
 
-  //In file Test.scala
+  // In file Test.scala
   class MyComponent extends Component {
     val value = in UInt(8 bits)
     val isZero = out(Bool())
@@ -497,7 +497,7 @@ Will generate
 
 
 In last resort
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 
 In last resort, if a signal has no name (anonymous signal), SpinalHDL will seek for a named signal which is driven by the anonymous signal, and use it as a name postfix :
 

--- a/source/SpinalHDL/Structuring/parametrization.rst
+++ b/source/SpinalHDL/Structuring/parametrization.rst
@@ -1,5 +1,5 @@
 Parametrization
-==================
+===============
 
 There are multiple aspects to parametrization :
 
@@ -28,7 +28,7 @@ IP for those scenarios your project requires.
 
 
 Elaboration time parameters
-------------------------------------------
+---------------------------
 
 You can use the whole Scala syntax to provide elaboration time parameters.
 
@@ -44,7 +44,7 @@ are suited to different parameter management scenarios.
 Here are some examples and ideas of the possibilities:
 
  * Hardwired code and constants (not strictly parameter management at all
-   but serves to hilight the most basic mechanism, a code change, not a
+   but serves to highlight the most basic mechanism, a code change, not a
    parameter data change)
  * Constant values provided from a companion object that are static
    constants in Scala.
@@ -87,7 +87,7 @@ pattern).
 A :ref:`ScopeProperty <scopeproperty>` can also be used for configuration.
 
 Optional hardware
-------------------------------------------
+-----------------
 
 So here there is more possibilities. 
 
@@ -111,10 +111,10 @@ result, otherwise it returns null.
 This may be used in cases to help parameterize the SpinalHDL hardware
 description using an elaboration-time conditional expression.  Causing HDL
 constructs to be emitted or not-emitted in the resulting HDL. The generate
-method can be seen as SpinalHDL syntatic sugar reducing language clutter.
+method can be seen as SpinalHDL syntactic sugar reducing language clutter.
 
 Project SpinalHDL code referencing ``mySignal`` would need to ensure it
-handles the possiblity of null gracefully.  This is usually not a problem
+handles the possibility of null gracefully.  This is usually not a problem
 as those parts of the design can also be omitted dependant on the ``flag``
 value.  Thus the feature of parameterizing this component is demonstrated.
 
@@ -129,7 +129,7 @@ If you want to disable the generation of a chunk of hardware :
 
   case class MyComponent(flag : Boolean) extends Component {
     val myHardware = flag generate new Area {
-      //optional hardware here
+      // optional hardware here
     }
   }
 

--- a/source/SpinalHDL/miscelenea/core/core_components.rst
+++ b/source/SpinalHDL/miscelenea/core/core_components.rst
@@ -62,7 +62,7 @@ An applied example to define a specific clock domain within the design is as fol
    ...
 
    // Use this domain in an area of the design
-   val coreArea = new ClockingArea(coreClockDomain){
+   val coreArea = new ClockingArea(coreClockDomain) {
      val coreClockedRegister = Reg(UInt(4 bits))
    }
 
@@ -101,7 +101,7 @@ In addition to the constructor parameters given :ref:`here <core_componets_clock
        resetActiveLevel = LOW
      )
      val myClockDomain = ClockDomain(io.clk,io.resetn,config = myClockDomainConfig)
-     val myArea = new ClockingArea(myClockDomain){
+     val myArea = new ClockingArea(myClockDomain) {
        val myReg = Reg(UInt(4 bits)) init(7)
        myReg := myReg + 1
 
@@ -128,7 +128,7 @@ You can define everywhere a clock domain which is driven by the outside. It will
        val result = out UInt (4 bits)
      }
      val myClockDomain = ClockDomain.external("myClockName")
-     val myArea = new ClockingArea(myClockDomain){
+     val myArea = new ClockingArea(myClockDomain) {
        val myReg = Reg(UInt(4 bits)) init(7)
        myReg := myReg + 1
 
@@ -165,7 +165,7 @@ There are multiple assignment operator :
    :header-rows: 1
    :widths: 1 5
 
-   * - Symbole
+   * - Symbol
      - Description
    * - :=
      - | Standard assignment, equivalent to '<=' in VHDL/Verilog
@@ -175,24 +175,24 @@ There are multiple assignment operator :
        | value updated instantly
    * - <>
      - | Automatic connection between 2 signals. Direction is inferred by using signal direction (in/out)
-       | Similar behavioural than :=
+       | Similar behavioral than :=
 
 
 .. code-block:: scala
 
-   //Because of hardware concurrency is always read with the value '1' by b and c
+   // Because of hardware concurrency is always read with the value '1' by b and c
    val a,b,c = UInt(4 bits)
    a := 0
    b := a
-   a := 1  //a := 1 win
+   a := 1  // a := 1 win
    c := a  
 
    var x = UInt(4 bits)
    val y,z = UInt(4 bits)
    x := 0
-   y := x      //y read x with the value 0
+   y := x      // y read x with the value 0
    x \= x + 1
-   z := x      //z read x with the value 1
+   z := x      // z read x with the value 1
 
 SpinalHDL check that bitcount of left and right assignment side match. There is multiple ways to adapt bitcount of BitVector (Bits, UInt, SInt) :
 
@@ -208,13 +208,13 @@ SpinalHDL check that bitcount of left and right assignment side match. There is 
      - Assign x with a resized copy of y, size is manually calculated
 
 
-There are 2 cases where spinal automaticly resize things :
+There are 2 cases where spinal automatically resize things :
 
 .. list-table::
    :header-rows: 1
    :widths: 3 2 1
 
-   * - Assignement
+   * - Assignment
      - Problem
      - SpinalHDL action
    * - myUIntOf_8bit := U(3)
@@ -232,23 +232,23 @@ As VHDL and Verilog, wire and register can be conditionally assigned by using wh
 
 .. code-block:: scala
 
-   when(cond1){
-     //execute when      cond1 is true
-   }.elsewhen(cond2){
-     //execute when (not cond1) and cond2
-   }.otherwise{
-     //execute when (not cond1) and (not cond2)
+   when(cond1) {
+     // execute when      cond1 is true
+   }.elsewhen(cond2) {
+     // execute when (not cond1) and cond2
+   }.otherwise {
+     // execute when (not cond1) and (not cond2)
    }
 
-   switch(x){
-     is(value1){
-       //execute when x === value1
+   switch(x) {
+     is(value1) {
+       // execute when x === value1
      }
-     is(value2){
-       //execute when x === value2
+     is(value2) {
+       // execute when x === value2
      }
-     default{
-       //execute if none of precedent condition meet
+     default {
+       // execute if none of precedent condition meet
      }
    }
 
@@ -259,7 +259,7 @@ You can also define new signals into a when/switch statement. It's useful if you
    val toto,titi = UInt(4 bits)
    val a,b = UInt(4 bits)
 
-   when(cond){
+   when(cond) {
      val tmp = a + b
      toto := tmp
      titi := tmp + 1
@@ -276,22 +276,22 @@ Like in VHDL and Verilog, you can define components that could be used to build 
 .. code-block:: scala
 
    class AdderCell extends Component {
-     //Declaring all in/out in an io Bundle is probably a good practice
+     // Declaring all in/out in an io Bundle is probably a good practice
      val io = new Bundle {
        val a, b, cin = in Bool()
        val sum, cout = out Bool()
      }
-     //Do some logic
+     // Do some logic
      io.sum := io.a ^ io.b ^ io.cin
      io.cout := (io.a & io.b) | (io.a & io.cin) | (io.b & io.cin)
    }
 
    class Adder(width: Int) extends Component {
      ...
-     //Create 2 AdderCell
+     // Create 2 AdderCell
      val cell0 = new AdderCell
      val cell1 = new AdderCell
-     cell1.io.cin := cell0.io.cout //Connect carrys
+     cell1.io.cin := cell0.io.cout // Connect carrys
      ...
      val cellArray = Array.fill(width)(new AdderCell)
      ...
@@ -365,7 +365,7 @@ The ways you can use Scala functions to generate hardware are radically differen
 * You can instantiate register, combinatorial logic and component inside them.
 * You don't have to play with ``process``\ /\ ``@always`` that limit the scope of assignment of signals
 * | Everything work by reference, which allow many manipulation.
-  | For example you can give to a function an bus as argument, then the function can internaly read/write it.
+  | For example you can give to a function an bus as argument, then the function can internally read/write it.
   | You can also return a Component, a Bus, are anything else from scala the scala world.
 
 RGB to gray
@@ -381,7 +381,7 @@ For example if you want to convert a Red/Green/Blue color into a gray one by usi
    // Define a function to multiply a UInt by a scala Float value.
    def coef(value : UInt,by : Float) : UInt = (value * U((255*by).toInt,8 bits) >> 8)
 
-   //Calculate the gray level
+   // Calculate the gray level
    val gray = coef(r,0.3f) +
               coef(g,0.4f) +
               coef(b,0.3f)
@@ -398,7 +398,7 @@ For instance if you define a simple Valid Ready Payload bus, you can then define
      val ready = Bool()
      val payload = Bits(payloadWidth bits)
 
-     //connect that to this
+     // connect that to this
      def <<(that: MyBus) : Unit = {
        this.valid := that.valid
        that.ready := this.ready
@@ -423,21 +423,21 @@ There is a small component and a ``main`` that generate the corresponding VHDL.
    // spinal.core contain all basics (Bool, UInt, Bundle, Reg, Component, ..)
    import spinal.core._
 
-   //A simple component definition
+   // A simple component definition
    class MyTopLevel extends Component {
-     //Define some input/output. Bundle like a VHDL record or a verilog struct.
+     // Define some input/output. Bundle like a VHDL record or a verilog struct.
      val io = new Bundle {
        val a = in Bool()
        val b = in Bool()
        val c = out Bool()
      }
 
-     //Define some asynchronous logic
+     // Define some asynchronous logic
      io.c := io.a & io.b
    }
 
-   //This is the main of the project. It create a instance of MyTopLevel and
-   //call the SpinalHDL library to flush it into a VHDL file.
+   // This is the main of the project. It create a instance of MyTopLevel and
+   // call the SpinalHDL library to flush it into a VHDL file.
    object MyMain {
      def main(args: Array[String]) {
        SpinalVhdl(new MyTopLevel)

--- a/source/SpinalHDL/miscelenea/frequent_errors.rst
+++ b/source/SpinalHDL/miscelenea/frequent_errors.rst
@@ -21,7 +21,7 @@ Exception in thread "main" java.lang.NullPointerException
 
 .. code-block:: scala
 
-   val a = b + 1         //b can't be read at that time, because b isn't instantiated yet
+   val a = b + 1         // b can't be read at that time, because b isn't instantiated yet
    val b = UInt(4 bits)
 
 **Issue explanation :**
@@ -46,40 +46,40 @@ Signal X can't be assigned by Y
 
 .. code-block:: scala
 
-   class ComponentX extends Component{
+   class ComponentX extends Component {
      ...
      val X = Bool()
      ...
    }
 
-   class ComponentY extends Component{
+   class ComponentY extends Component {
      ...
      val componentX = new ComponentX
      val Y = Bool()
-     componentX.X := Y //This assignment is not legal
+     componentX.X := Y // This assignment is not legal
      ...
    }
 
 .. code-block:: scala
 
-   class ComponentX extends Component{
-     val io = new Bundle{
-       val X = Bool() //Forgot to specify an in/out direction
+   class ComponentX extends Component {
+     val io = new Bundle {
+       val X = Bool() // Forgot to specify an in/out direction
      }
      ...
    }
 
-   class ComponentY extends Component{
+   class ComponentY extends Component {
      ...
      val componentX = new ComponentX
      val Y = Bool()
-     componentX.io.X := Y //This assignment will be detected as not legal
+     componentX.io.X := Y // This assignment will be detected as not legal
      ...
    }
 
 **Issue explanation :**
 
-You can only assign input signals of subcomponents, else there is an hierarchy violation. If this issue happend, you probably forgot to specify the X signal's direction.
+You can only assign input signals of subcomponents, else there is an hierarchy violation. If this issue happened, you probably forgot to specify the X signal's direction.
 
 Input signal X can't be assigned by Y
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -94,19 +94,19 @@ Input signal X can't be assigned by Y
 
 .. code-block:: scala
 
-   class ComponentXY extends Component{
-     val io = new Bundle{
+   class ComponentXY extends Component {
+     val io = new Bundle {
        val X = in Bool()
      }
      ...
      val Y = Bool()
-     io.X := Y //This assignment is not legal
+     io.X := Y // This assignment is not legal
      ...
    }
 
 **Issue explanation :**
 
-You can only assign an input signals from the parent component, else there is an hierarchy violation. If this issue happend, you probably mixed signals direction declaration.
+You can only assign an input signals from the parent component, else there is an hierarchy violation. If this issue happened, you probably mixed signals direction declaration.
 
 Output signal X can't be assigned by Y
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -121,21 +121,21 @@ Output signal X can't be assigned by Y
 
 .. code-block:: scala
 
-   class ComponentX extends Component{
-     val io = new Bundle{
+   class ComponentX extends Component {
+     val io = new Bundle {
        val X = out Bool()
      }
      ...
    }
 
-   class ComponentY extends Component{
+   class ComponentY extends Component {
      ...
      val componentX = new ComponentX
      val Y = Bool()
-     componentX.X := Y //This assignment is not legal
+     componentX.X := Y // This assignment is not legal
      ...
    }
 
 **Issue explanation :**
 
-You can only assign output signals of a component from the inside of it, else there is an hierarchy violation. If this issue happend, you probably mixed signals direction declaration.
+You can only assign output signals of a component from the inside of it, else there is an hierarchy violation. If this issue happened, you probably mixed signals direction declaration.


### PR DESCRIPTION
It was rainy this weekend, so I did some spelling fix in the doc :). 

The "Code Spell Checker" extension in vscode helped a lot, but nothing was done automatically, and I reviewed all the changes before committing.

---
American english was used and replace sometime British english (what is not wrong in itself) because it's more consistent. Neologisms (like "blackboxing"), word fusions (like "bitmask") were left untouched.

Also trimmed rst title bars.