### PR TITLE
docs: fix duplicated headings and navigation order in 'Getting Starte…

### DIFF
--- a/source/SpinalHDL/Getting Started/Scala Guide/index.rst
+++ b/source/SpinalHDL/Getting Started/Scala Guide/index.rst
@@ -10,11 +10,6 @@ Scala Guide
    interaction
 
 
-Scala guide
-===========
-
-Introduction
-------------
 Scala is a very capable programming language that was influenced by a unique set of languages, but often, this set of languages doesn't cross the ones that most programmers use. That can hinder newcomers' understanding of the concepts and design choices behind Scala.
 
 The following pages will present Scala, and try to provide enough information about it for newcomers to be comfortable with SpinalHDL.


### PR DESCRIPTION
I noticed a structural issue in the **Scala Guide** chapter where the navigation sidebar showed duplicated "Scala Guide" entries and the introductory text was misplaced at the bottom of the navigation tree.

<img width="742" height="1021" alt="image" src="https://github.com/user-attachments/assets/d204b6e5-18dd-4805-a536-2a24b7657432" />

To fix this, I have:

- Removed the redundant H1 and H2 headings in `index.rst`.

- Streamlined the page flow so that the introduction text serves as the direct body of the chapter.

I believe that having the introductory text immediately follow the main title is clear enough and provides a better user experience without an explicit "Introduction" sub-heading.

As this is my first time working with `.rst` files, I have verified the changes locally with make html to ensure the sidebar and page hierarchy now look correct and consistent with other chapters. I hope this helps!

<img width="2022" height="1130" alt="image" src="https://github.com/user-attachments/assets/4261080c-dbf9-4336-8614-0f8609bae3f5" />
