### PR TITLE
Remove inexistent SpinalConfig.shell --debug option

### DIFF
--- a/source/SpinalHDL/Other language features/vhdl_generation.rst
+++ b/source/SpinalHDL/Other language features/vhdl_generation.rst
@@ -192,8 +192,6 @@ The syntax for command line arguments is:
            Select the VHDL mode
      --verilog
            Select the Verilog mode
-     -d | --debug
-           Enter in debug mode directly
      -o <value> | --targetDirectory <value>
            Set the target directory
 


### PR DESCRIPTION
My understanding form the code of shell here:

https://github.com/SpinalHDL/SpinalHDL/blob/00f4523f966038fa77d8a7b4955587556efff351/core/src/main/scala/spinal/core/Spinal.scala#L314

Is that the `--debug` option doesn't exist. I also get the error `[error] Error: Unknown option --debug` when using it.

I searched in the code for it but I think it doesn't exist (no arg in SpinalConfig). So I suppose it's an error in the doc.

This PR remove the `--debug` from the doc to avoid confusion.

By the way, my understanding is there is no way to increase HDL error verbosity (not only the verbose = true argument). Or do I miss something ?