### PR TITLE
Update Symbol to SymbolName in regIf.rst

### DIFF
--- a/source/SpinalHDL/Libraries/regIf.rst
+++ b/source/SpinalHDL/Libraries/regIf.rst
@@ -187,7 +187,7 @@ new way:
 
 .. code:: scala
    
-   M_REG0.field(Bits(32 bit), ROV, BigInt("F000A801", 16), "xx-device version")(Symbol("Version"))
+   M_REG0.field(Bits(32 bit), ROV, BigInt("F000A801", 16), "xx-device version")(SymbolName("Version"))
 
    
 


### PR DESCRIPTION
The implicit argument of **spinal.lib.bus.regif.RegInst#field** is **SymbolName** instead of **Symbol**